### PR TITLE
Add .pytest_cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
I ran the tests and noticed that a cache directory wasn't being ignored by git. So I add `.pytest_cache/` to `.gitignore`.

Broken tests are fixed with #167.