### PR TITLE
Add TensorBoard and CSVLogger callback support, Add target_episode_update to NAFAgent

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -717,6 +717,8 @@ class NAFAgent(AbstractDQNAgent):
             if self.processor is not None:
                 metrics += self.processor.metrics
 
+            print('metrics: ', self.combined_model.metrics_names, ' : ', metrics)
+
         if self.target_model_update >= 1:
             if self.target_episode_update:
                 if terminal:

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -717,8 +717,6 @@ class NAFAgent(AbstractDQNAgent):
             if self.processor is not None:
                 metrics += self.processor.metrics
 
-            print('metrics: ', self.combined_model.metrics_names, ' : ', metrics)
-
         if self.target_model_update >= 1:
             if self.target_episode_update:
                 if terminal:

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -7,8 +7,9 @@ from tempfile import mkdtemp
 
 import numpy as np
 
-from keras.callbacks import Callback as KerasCallback, CallbackList as KerasCallbackList
+from keras.callbacks import Callback as KerasCallback, CallbackList as KerasCallbackList, TensorBoard, CSVLogger
 from keras.utils.generic_utils import Progbar
+# from rl.core import Agent
 
 
 class Callback(KerasCallback):
@@ -35,6 +36,15 @@ class Callback(KerasCallback):
 
 
 class CallbackList(KerasCallbackList):
+    def set_model(self, model):
+        from rl.core import Agent
+        for callback in self.callbacks:
+            if issubclass(type(model), Agent) and \
+                    (issubclass(type(callback), TensorBoard)):
+                        callback.set_model(model.model)
+            else:
+                callback.set_model(model)
+
     def _set_env(self, env):
         for callback in self.callbacks:
             if callable(getattr(callback, '_set_env', None)):

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -356,3 +356,113 @@ class ModelIntervalCheckpoint(Callback):
         if self.verbose > 0:
             print('Step {}: saving model to {}'.format(self.total_steps, filepath))
         self.model.save_weights(filepath, overwrite=True)
+
+
+class RlTensorBoard(TensorBoard):
+    def __init__(self, log_dir='./logs',
+                 histogram_freq=0,
+                 batch_size=32,
+                 write_graph=True,
+                 write_grads=False,
+                 write_images=False,
+                 embeddings_freq=0,
+                 embeddings_layer_names=None,
+                 embeddings_metadata=None,
+                 agent=None):
+        super(RlTensorBoard, self).__init__(log_dir, histogram_freq, batch_size, write_graph, write_grads,
+                                            write_images, embeddings_freq, embeddings_layer_names,
+                                            embeddings_metadata)
+        self.agent = agent
+
+    def set_validation_data(self):
+        import numpy as np
+        experiences = self.agent.memory.sample(self.agent.batch_size)
+        # Start by extracting the necessary parameters (we use a vectorized implementation).
+        state0_batch = []
+        reward_batch = []
+        action_batch = []
+        terminal1_batch = []
+        state1_batch = []
+        for e in experiences:
+            state0_batch.append(e.state0)
+            state1_batch.append(e.state1)
+            reward_batch.append(e.reward)
+            action_batch.append(e.action)
+            terminal1_batch.append(0. if e.terminal1 else 1.)
+
+        # Prepare and validate parameters.
+        state0_batch = self.agent.process_state_batch(state0_batch)
+        state1_batch = self.agent.process_state_batch(state1_batch)
+        terminal1_batch = np.array(terminal1_batch)
+        reward_batch = np.array(reward_batch)
+        action_batch = np.array(action_batch)
+        assert reward_batch.shape == (self.batch_size,)
+        assert terminal1_batch.shape == reward_batch.shape
+        assert action_batch.shape == (self.agent.batch_size, self.agent.nb_actions)
+
+        # Compute Q values for mini-batch update.
+        q_batch = self.agent.target_V_model.predict_on_batch(state1_batch).flatten()
+        assert q_batch.shape == (self.batch_size,)
+
+        # Compute discounted reward.
+        discounted_reward_batch = self.agent.gamma * q_batch
+        # Set discounted reward to zero for all states that were terminal.
+        discounted_reward_batch *= terminal1_batch
+        assert discounted_reward_batch.shape == reward_batch.shape
+        Rs = reward_batch + discounted_reward_batch
+        assert Rs.shape == (self.agent.batch_size,)
+
+        self.validation_data = [action_batch, state0_batch, np.expand_dims(Rs, 1), np.ones(self.agent.batch_size)]
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.set_validation_data()
+        logs = logs or {}
+
+        if not self.validation_data and self.histogram_freq:
+            raise ValueError('If printing histograms, validation_data must be '
+                             'provided, and cannot be a generator.')
+        if self.validation_data and self.histogram_freq:
+            if epoch % self.histogram_freq == 0:
+                val_data = self.validation_data
+                tensors = (self.model.inputs +
+                           self.model.targets +
+                           self.model.sample_weights)
+                if self.model.uses_learning_phase:
+                    tensors += [K.learning_phase()]
+
+                assert len(val_data) == len(tensors)
+                val_size = val_data[0].shape[0]
+                i = 0
+                while i < val_size:
+                    step = min(self.batch_size, val_size - i)
+                    if self.model.uses_learning_phase:
+                        # do not slice the learning phase
+                        batch_val = [x[i:i + step] for x in val_data[:-1]]
+                        batch_val.append(val_data[-1])
+                    else:
+                        batch_val = [x[i:i + step] for x in val_data]
+                    assert len(batch_val) == len(tensors)
+                    feed_dict = dict(zip(tensors, batch_val))
+                    result = self.sess.run([self.merged], feed_dict=feed_dict)
+                    summary_str = result[0]
+                    self.writer.add_summary(summary_str, epoch)
+                    i += self.batch_size
+
+        if self.embeddings_freq and self.embeddings_ckpt_path:
+            if epoch % self.embeddings_freq == 0:
+                self.saver.save(self.sess,
+                                self.embeddings_ckpt_path,
+                                epoch)
+
+        for name, value in logs.items():
+            if name in ['batch', 'size']:
+                continue
+            summary = tf.Summary()
+            summary_value = summary.value.add()
+            try:
+                summary_value.simple_value = value.item()
+            except:
+                summary_value.simple_value = value
+            summary_value.tag = name
+            self.writer.add_summary(summary, epoch)
+        self.writer.flush()

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -414,7 +414,7 @@ class RlTensorBoard(TensorBoard):
 
         self.validation_data = [action_batch, state0_batch, np.expand_dims(Rs, 1), np.ones(self.agent.batch_size)]
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_episode_end(self, episode, logs=None):
         import tensorflow as tf
         self.set_validation_data()
         logs = logs or {}
@@ -423,7 +423,7 @@ class RlTensorBoard(TensorBoard):
             raise ValueError('If printing histograms, validation_data must be '
                              'provided, and cannot be a generator.')
         if self.validation_data and self.histogram_freq:
-            if epoch % self.histogram_freq == 0:
+            if episode % self.histogram_freq == 0:
                 val_data = self.validation_data
                 tensors = (self.model.inputs +
                            self.model.targets +
@@ -446,14 +446,14 @@ class RlTensorBoard(TensorBoard):
                     feed_dict = dict(zip(tensors, batch_val))
                     result = self.sess.run([self.merged], feed_dict=feed_dict)
                     summary_str = result[0]
-                    self.writer.add_summary(summary_str, epoch)
+                    self.writer.add_summary(summary_str, episode)
                     i += self.batch_size
 
         if self.embeddings_freq and self.embeddings_ckpt_path:
-            if epoch % self.embeddings_freq == 0:
+            if episode % self.embeddings_freq == 0:
                 self.saver.save(self.sess,
                                 self.embeddings_ckpt_path,
-                                epoch)
+                                episode)
 
         for name, value in logs.items():
             if name in ['batch', 'size']:
@@ -465,5 +465,5 @@ class RlTensorBoard(TensorBoard):
             except:
                 summary_value.simple_value = value
             summary_value.tag = name
-            self.writer.add_summary(summary, epoch)
+            self.writer.add_summary(summary, episode)
         self.writer.flush()

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -415,6 +415,7 @@ class RlTensorBoard(TensorBoard):
         self.validation_data = [action_batch, state0_batch, np.expand_dims(Rs, 1), np.ones(self.agent.batch_size)]
 
     def on_epoch_end(self, epoch, logs=None):
+        import tensorflow as tf
         self.set_validation_data()
         logs = logs or {}
 

--- a/rl/core.py
+++ b/rl/core.py
@@ -114,6 +114,7 @@ class Agent(object):
         did_abort = False
         try:
             while self.step < nb_steps:
+                self.training = True
                 if observation is None:  # start of a new episode
                     callbacks.on_episode_begin(episode)
                     self.episode_step = 0
@@ -186,6 +187,8 @@ class Agent(object):
                 metrics = self.backward(reward, terminal=done)
                 episode_reward += reward
 
+                # AHA
+                last_distance = info['distance']
                 step_logs = {
                     'action': action,
                     'observation': observation,
@@ -207,11 +210,17 @@ class Agent(object):
                     self.forward(observation)
                     self.backward(0., terminal=False)
 
+                    # AHA
+                    # Conflict becuase test sets step=0
+                    # test_history = self.test(env, nb_episodes=10, nb_max_episode_steps=4)
+
                     # This episode is finished, report and reset.
                     episode_logs = {
                         'episode_reward': episode_reward,
                         'nb_episode_steps': self.episode_step,
                         'nb_steps': self.step,
+                        'last_train_distance': last_distance,
+                        # 'last_test_distance': np.mean(test_history.history['last_distance'])
                     }
                     callbacks.on_episode_end(episode, episode_logs)
 
@@ -332,6 +341,9 @@ class Agent(object):
                 self.backward(reward, terminal=done)
                 episode_reward += reward
 
+                # AHA
+                last_distance = info['distance']
+
                 step_logs = {
                     'action': action,
                     'observation': observation,
@@ -355,6 +367,7 @@ class Agent(object):
             episode_logs = {
                 'episode_reward': episode_reward,
                 'nb_steps': self.episode_step,
+                'last_distance': last_distance
             }
             callbacks.on_episode_end(episode, episode_logs)
         callbacks.on_train_end()

--- a/rl/core.py
+++ b/rl/core.py
@@ -129,7 +129,7 @@ class Agent(object):
                 if observation is None:  # start of a new episode
                     callbacks.on_episode_begin(episode)
 
-                    episode_step = np.int16(0)
+                    self.episode_step = np.int16(0)
                     episode_reward = np.float32(0)
 
                     # Obtain the initial observation by resetting the environment.


### PR DESCRIPTION
Three files are modified as follows.

`rl/agents/dqn.py`:
`target_episode_update` attribute: when set to True, target model is only updated at the end of the episode

`rl/callbacks.py` and `rl/core.py`:
CSVLogger: To add support for CSVLogger, the following line is added:
`self.stop_training = False`

TensorBoard: To add support for TensorBoard, the wrapper class `RlTensorBoard` is defined which fills the `self.validation_data` in the beginning of the `on_epoch_end` method. The `on_epoch_end` is also altered to enable visualisation of `log` data in tensorboard.
Lastly, the `set_model` method of CallbackList(KerasCallbackList) is overridden. 