### PR TITLE
Remove legacy code, argument `force` in keras.utils.generic_utils.Progbar doesn't works now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy matplotlib pandas pytest h5py
   - source activate test-environment
   - pip install pytest-xdist
   # See https://github.com/pytest-dev/pytest-cov/issues/124 for details
@@ -44,9 +44,10 @@ install:
   - pip install tensorflow
   # Bleeding-edge: pip install git+https://github.com/Theano/Theano.git
   - pip install "theano<1.0"
-  - pip install gym
+  - pip install gym==0.9.5
+  - pip install scipy
   # Bleeding-edge: pip install git+https://github.com/fchollet/keras.git;
-  - pip install "keras>=2.0.7";
+  - pip install "keras>=2.0.7,<=2.1.3";
   - python setup.py install
 
 # command to run tests.

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -242,7 +242,7 @@ class TrainIntervalLogger(Callback):
         if self.info_names is None:
             self.info_names = logs['info'].keys()
         values = [('reward', logs['reward'])]
-        self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
+        self.progbar.update((self.step % self.interval) + 1, values=values)
         self.step += 1
         self.metrics.append(logs['metrics'])
         if len(self.info_names) > 0:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='keras-rl',
       url='https://github.com/matthiasplappert/keras-rl',
       download_url='https://github.com/matthiasplappert/keras-rl/archive/v0.4.0.tar.gz',
       license='MIT',
-      install_requires=['keras>=2.0.7'],
+      install_requires=['keras>=2.0.7,<=2.1.3'],
       extras_require={
           'gym': ['gym'],
       },


### PR DESCRIPTION
Hello I love keras-rl but this bug should be fixed.
When I tried to use `TrainEpisodeLogger`, below error occurred.
```
Traceback (most recent call last):
  File "train.py", line 49, in <module>
    main()
  File "train.py", line 42, in main
    nb_steps_per_episode * 1000)
  File "/Users/iwasa_kosui/.anyenv/envs/pyenv/versions/3.6.4/lib/python3.6/site-packages/rl/core.py", line 196, in fit
    callbacks.on_step_end(episode_step, step_logs)
  File "/Users/KilledByNLP/.anyenv/envs/pyenv/versions/3.6.4/lib/python3.6/site-packages/rl/callbacks.py", line 75, in on_step_end
    callback.on_step_end(step, logs=logs)
  File "/Users/KilledByNLP/.anyenv/envs/pyenv/versions/3.6.4/lib/python3.6/site-packages/rl/callbacks.py", line 245, in on_step_end
    self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
TypeError: update() got an unexpected keyword argument 'force'
```

The error occurs in `rl/callbacks.py`, [line 245](https://github.com/matthiasplappert/keras-rl/blob/master/rl/callbacks.py#L245)
```python
self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
```

As a result of comparing it with the source code of keras, `force` argument we use is already removed.
https://github.com/keras-team/keras/commit/a2e3d24fcbe73e9cf8b5b1737b1b2913960f7d96

Namely, we just have to remove the argument `force=True`.

```python
- self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
+ self.progbar.update((self.step % self.interval) + 1, values=values) 
```

Thank you.
