### PR TITLE
Fix Travis builds and specify an upper bound for Keras version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - pip install "theano<1.0"
   - pip install gym
   # Bleeding-edge: pip install git+https://github.com/fchollet/keras.git;
-  - pip install "keras>=2.0.7";
+  - pip install "keras>=2.0.7,<=2.1.3";
   - python setup.py install
 
 # command to run tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - pip install tensorflow
   # Bleeding-edge: pip install git+https://github.com/Theano/Theano.git
   - pip install "theano<1.0"
-  - pip install gym
+  - pip install gym==0.9.5
   # Bleeding-edge: pip install git+https://github.com/fchollet/keras.git;
   - pip install "keras>=2.0.7,<=2.1.3";
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy matplotlib pandas pytest h5py
   - source activate test-environment
   - pip install pytest-xdist
   # See https://github.com/pytest-dev/pytest-cov/issues/124 for details
@@ -45,6 +45,7 @@ install:
   # Bleeding-edge: pip install git+https://github.com/Theano/Theano.git
   - pip install "theano<1.0"
   - pip install gym==0.9.5
+  - pip install scipy
   # Bleeding-edge: pip install git+https://github.com/fchollet/keras.git;
   - pip install "keras>=2.0.7,<=2.1.3";
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='keras-rl',
       url='https://github.com/matthiasplappert/keras-rl',
       download_url='https://github.com/matthiasplappert/keras-rl/archive/v0.4.0.tar.gz',
       license='MIT',
-      install_requires=['keras>=2.0.7'],
+      install_requires=['keras>=2.0.7,<=2.1.3'],
       extras_require={
           'gym': ['gym'],
       },


### PR DESCRIPTION
keras-rl is no longer compatible with versions of Keras over 2.1.3 (as shown in #171). So before the necessary changes are merged, the master version should specify an upper bound for the version of Keras.