### PR TITLE
Fix OrnsteinUhlenbeck reset

### DIFF
--- a/rl/random.py
+++ b/rl/random.py
@@ -40,12 +40,11 @@ class GaussianWhiteNoiseProcess(AnnealedGaussianProcess):
 
 # Based on http://math.stackexchange.com/questions/1287634/implementing-ornstein-uhlenbeck-in-matlab
 class OrnsteinUhlenbeckProcess(AnnealedGaussianProcess):
-    def __init__(self, theta, mu=0., sigma=1., dt=1e-2, x0=None, size=1, sigma_min=None, n_steps_annealing=1000):
+    def __init__(self, theta, mu=0., sigma=1., dt=1e-2, size=1, sigma_min=None, n_steps_annealing=1000):
         super(OrnsteinUhlenbeckProcess, self).__init__(mu=mu, sigma=sigma, sigma_min=sigma_min, n_steps_annealing=n_steps_annealing)
         self.theta = theta
         self.mu = mu
         self.dt = dt
-        self.x0 = x0
         self.size = size
         self.reset_states()
 
@@ -56,4 +55,4 @@ class OrnsteinUhlenbeckProcess(AnnealedGaussianProcess):
         return x
 
     def reset_states(self):
-        self.x_prev = self.x0 if self.x0 is not None else np.zeros(self.size)
+        self.x_prev = np.random.normal(self.mu,self.current_sigma,self.size)


### PR DESCRIPTION
The agent resets its states (including the noise process) at the start of each episode. 
The `reset_states` of the Ornstein-Uhlenbeck method counteracts the annealing of the standard deviation by setting a `x0` with another sigma than the current one (or even fixed values). 

First case -- `x0` is `None`: The noise values are forced back to 0 and have to be built up from there. This results in inhibited exploration at the start of each episode, i.e. variations of the first steps are barely explored.
You can see this in this plot where the process is reset every 1000 steps: https://raw.githubusercontent.com/Frawak/keras-rl/ShowOU/assets/OUReset1.png

Second case -- `x0` with a fixed sigma: As mentioned above, the annealing is torpedoed by resetting to certain values with a standard deviation different from the current one. This results in noise when you do not want any. In addition, the noise is "one-sided".
The following plot anneals `sigma` to a `sigma_min == 0.01` after 2000 steps and resets every 1000 steps: https://raw.githubusercontent.com/Frawak/keras-rl/ShowOU/assets/OUReset2.png

So, I removed x0 and reset the process according to `current_sigma`.