### PR TITLE
[WIP] Synchronous PPO Agent

### DIFF
--- a/rl/agents/ppo.py
+++ b/rl/agents/ppo.py
@@ -1,0 +1,51 @@
+import os
+
+from rl.core import Agent
+
+
+class PPOAgent(Agent):
+    def __init__(self, actor, critic, memory, nb_actor=3, nb_steps=1000, epoch=5, **kwargs):
+        super(Agent, self).__init__(**kwargs)
+
+        # Parameters.
+        self.nb_actor = nb_actor
+        self.nb_steps = nb_steps
+        self.epoch = epoch
+
+        # Related objects.
+        self.actor = actor
+        self.critic = critic
+        self.memory = memory
+
+    def compile(self, optimizer, metrics=[]):
+        # TODO
+        pass
+
+    def load_weights(self, filepath):
+        filename, extension = os.path.splitext(filepath)
+        actor_filepath = filename + '_actor' + extension
+        critic_filepath = filename + '_critic' + extension
+        self.actor.load_weights(actor_filepath)
+        self.critic.load_weights(critic_filepath)
+
+    def save_weights(self, filepath, overwrite=False):
+        filename, extension = os.path.splitext(filepath)
+        actor_filepath = filename + '_actor' + extension
+        critic_filepath = filename + '_critic' + extension
+        self.actor.save_weights(actor_filepath, overwrite=overwrite)
+        self.critic.save_weights(critic_filepath, overwrite=overwrite)
+
+    def forward(self, observation):
+        # TODO
+        pass
+
+    @property
+    def layers(self):
+        return self.actor.layers[:] + self.critic.layers[:]
+
+    def backward(self, reward, terminal=False):
+        # Store most recent experience in memory.
+        if self.step % self.memory_interval == 0:
+            self.memory.append(self.recent_observation, self.recent_action, reward, terminal,
+                               training=self.training)
+        # TODO

--- a/rl/agents/ppo.py
+++ b/rl/agents/ppo.py
@@ -211,6 +211,14 @@ class PPOAgent(Agent):
             self.target_actor.set_weights(self.actor.get_weights())
 
             #TODO: train value network
+            predict_value = self.critic.predict_on_batch(batch_state[1:]).flatten()
+            # Compute r_t + gamma * V(s_t+1) and update the target ys accordingly,
+            discounted_reward_batch = self.gamma * predict_value
+            #discounted_reward_batch *= terminal1_batch
+            assert discounted_reward_batch.shape == batch_reward.shape
+            targets = (batch_reward + discounted_reward_batch).reshape(self.batch_size, 1)
+
+            self.critic.train_on_batch(batch_state[:-1], targets)
 
             # reset all episode memories
             self.episode_memories = [EpisodeMemory(state=FixedBuffer(self.nb_steps), windowed_state=None,

--- a/rl/agents/ppo.py
+++ b/rl/agents/ppo.py
@@ -158,7 +158,7 @@ class PPOAgent(Agent):
             layer.trainable = False
             layer.name += '_copy'
         #self.actor.compile(optimizer='sgd', loss='mse')
-        self.critic.compile(optimizer=critic_optimizer)
+        self.critic.compile(optimizer=critic_optimizer, loss='mse')
 
         # Model for the overall objective
         actor_input_shape = self.actor.inputs[self.actor_input_index]._keras_shape[1:]
@@ -188,6 +188,8 @@ class PPOAgent(Agent):
         self.round = 0
         self.current_episode_memory = self.episode_memories[0]
         self.finalize_episode = False
+
+        self.compiled = True
 
     def load_weights(self, filepath):
         filename, extension = os.path.splitext(filepath)

--- a/rl/agents/ppo.py
+++ b/rl/agents/ppo.py
@@ -25,15 +25,31 @@ def state_windowing(states, window_len):
 
 # TODO: We would need a new memory class that returns windowed info also for rewards
 class PPOAgent(Agent):
-    # Note on network architecture:
-    # actor should take as input a window of recent state, and should output a vector in the abstract
-    # sample space as defined by the user, which is then feed into the sampler, again supplied
-    # by the user. This sampler is responsible for transforming the abstract sample space into
-    # actual value in the action space, through a (known, fixed) random distribution
-    # actor input shape: (window_length, dimension of observation space)
-    # critic's only input is the current state, and should output a scalar representing estimated
-    # value of this state
-    # critic input shape: (dimension of observation space,)
+    """
+    Single threaded implementation of the Proximal Policy Optimization algorithm, using an A2C (Advantage
+    Actor-Critic) architecture.
+
+    Note on network architecture
+    ============================
+    actor should take as input a window of recent state, and should output a vector in the abstract
+    sample space as defined by the user, which is then feed into the sampler, again supplied
+    by the user. This sampler is responsible for transforming the abstract sample space into
+    actual value in the action space, through a (known, fixed) random distribution
+    actor input shape: (window_length, dimension of observation space)
+    critic's only input is the current state, and should output a scalar representing estimated
+    value of this state
+    critic input shape: (dimension of observation space,)
+
+    :param actor: Actor network
+    :param critic: Critic network
+    :param memory: Memory object to hold a history of simulation run. As opposed to other agents, we only use it
+    superficially as replay buffer is not used in A2C architecture.
+    :param sampler: User supplied sampler. See notes above for explanation.
+    :param epsilon: Cutoff for the clipped loss function
+    :param nb_actor: Number of concurrent actors running simulation (They are still executed sequential in this version)
+    :param nb_steps: Number of steps to run in each simulation episode before termination. Should match with xx in yy
+    :param epoch: Number of training epoch for the actor network.
+    """
     def __init__(self, actor, critic, memory, sampler, epsilon=0.2, nb_actor=3, nb_steps=1000, epoch=5, **kwargs):
         super(Agent, self).__init__(**kwargs)
 

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -60,10 +60,16 @@ class RingBuffer(object):
         self.data[(self.start + self.length - 1) % self.maxlen] = v
 
 class FixedBuffer(object):
-    def __init__(self, maxlen):
+    def __init__(self, maxlen, val=None):
         self.maxlen = maxlen
-        self.length = 0
-        self.data = [None for _ in range(maxlen)]
+        if val is None:
+            self.data = [None for _ in range(maxlen)]
+            self.length = 0
+        else:
+            if maxlen < len(val):
+                raise AttributeError()
+            self.data = val
+            self.length = len(val)
 
     def __len__(self):
         return self.length

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -59,6 +59,33 @@ class RingBuffer(object):
             raise RuntimeError()
         self.data[(self.start + self.length - 1) % self.maxlen] = v
 
+class FixedBuffer(object):
+    def __init__(self, maxlen):
+        self.maxlen = maxlen
+        self.length = 0
+        self.data = [None for _ in range(maxlen)]
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, idx):
+        if idx < 0 or idx >= self.length:
+            raise KeyError()
+        return self.data[idx]
+
+    def __setitem__(self, idx, value):
+        if idx < 0 or idx >= self.length:
+            raise KeyError()
+        self.data[idx] = value
+
+    def append(self, value):
+        if self.length >= self.maxlen:
+            raise KeyError()
+        self.data[self.length] = value
+        self.length += 1
+
+    def get_list(self):
+        return self.data[:self.length]
 
 def zeroed_observation(observation):
     if hasattr(observation, 'shape'):

--- a/rl/policy.py
+++ b/rl/policy.py
@@ -97,6 +97,12 @@ class GreedyQPolicy(Policy):
         action = np.argmax(q_values)
         return action
 
+class SimpleProbabilisticPolicy(Policy):
+    def select_action(self, p_values):
+        assert p_values.ndim == 1
+        nb_actions = p_values.shape[0]
+        return np.random.choice(nb_actions, p=p_values)
+
 
 class BoltzmannQPolicy(Policy):
     def __init__(self, tau=1., clip=(-500., 500.)):

--- a/rl/random.py
+++ b/rl/random.py
@@ -69,7 +69,14 @@ class ProbabilityDistribution(object):
         Generate a single random sample according to the probability distribution.
 
         :param x: Python list of parameters for the random vector, where each parameter is a numpy array.
-        :return: Sampled value. Should be a numpy array.
+        :return: Sampled value. Should be a numpy array with dimension same as ``self.sample_dim()``.
+        """
+        pass
+
+    def sample_dim(self):
+        """
+        Get the tensor dimension spec for the generated random sample
+        :return: Dimension of the random samples
         """
         pass
 
@@ -107,6 +114,9 @@ class IndependentGaussianProcess(ProbabilityDistribution):
         assert mu.shape == (self.n,)
         assert log_sigma.shape == (self.n,)
         return np.random.normal(mu, np.exp(log_sigma))
+
+    def sample_dim(self):
+        return (self.n,)
 
     def get_dist(self, x):
         mu, log_sigma, y = x

--- a/rl/random.py
+++ b/rl/random.py
@@ -92,8 +92,8 @@ class IndependentGaussianProcess(ProbabilityDistribution):
     Specifies a Multivariate Gaussian/Normal Distribution, with a diagonal covariance matrix (i.e. each component
     in the random vector are independent).
 
-    The random parameters are ``mu`` (mean) and ``sigma`` (standard deviation), both numpy array of shape
-    ``(n,)``, where n is the dimension of the random vector.
+    The random parameters are ``mu`` (mean) and ``log_sigma`` (natural log of standard deviation), both numpy
+    array of shape ``(n,)``, where n is the dimension of the random vector.
 
     The generated output is also a numpy array of shape ``(n,)``.
 
@@ -103,12 +103,12 @@ class IndependentGaussianProcess(ProbabilityDistribution):
         self.n = n
 
     def sample(self, x):
-        mu, sigma = x
+        mu, log_sigma = x
         assert mu.shape == (self.n,)
-        assert sigma.shape == (self.n,)
-        return np.random.normal(mu, sigma)
+        assert log_sigma.shape == (self.n,)
+        return np.random.normal(mu, np.exp(log_sigma))
 
     def get_dist(self, x):
-        mu, sigma, y = x
-        return K.constant(- self.n * math.log(2*math.pi) / 2 ) - K.sum(sigma, axis=1, keepdims=True) - \
-               K.sum(K.exp( 2 * K.log(K.abs(y - mu)) - K.constant(math.log(2.0)) - 2 * sigma), axis=1, keepdims=True)
+        mu, log_sigma, y = x
+        return K.constant(- self.n * math.log(2*math.pi) / 2 ) - K.sum(log_sigma, axis=1, keepdims=True) - \
+               K.sum(K.exp( 2 * K.log(K.abs(y - mu)) - K.constant(math.log(2.0)) - 2 * log_sigma), axis=1, keepdims=True)

--- a/rl/util.py
+++ b/rl/util.py
@@ -88,15 +88,16 @@ def GeneralizedAdvantageEstimator(critic, state_batch, reward, gamma, lamb):
     # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
     #
     # state_batch: a numpy array of batched input that can be feed into the critic network directly
+    #  note that it must also contain the ending state, i.e. has batch_size + 1 entries
     # reward: numpy array of shape (batch_size,)
-    n = len(state_batch)
+    n = len(state_batch) - 1
     assert reward.shape == (n,)
     value = critic.predict_on_batch(state_batch).flatten()
-    delta = reward + gamma * np.roll(value, -1) - value
+    delta = reward + gamma * value[1:, ] - value[:-1, ]
     # No premature optimization for now...
     result = [0]
     r = gamma * lamb
-    for i in range(1, n):
+    for i in range(0, n):
         result.append(result[-1] * r + delta[n-1-i])
     return result[:0:-1]
 

--- a/rl/util.py
+++ b/rl/util.py
@@ -123,3 +123,11 @@ class AdditionalUpdatesOptimizer(optimizers.Optimizer):
 
     def get_config(self):
         return self.optimizer.get_config()
+
+def state_windowing(states, window_len):
+    def naive_pad(x, shift, axis=0):
+        y = np.roll(x, shift, axis)
+        y[0:shift, ] = 0
+        return y
+
+    return np.stack( [ naive_pad(states, i, axis=0) for i in reversed(range(window_len))], axis=1 )

--- a/rl/util.py
+++ b/rl/util.py
@@ -84,12 +84,14 @@ def huber_loss(y_true, y_pred, clip_value):
         raise RuntimeError('Unknown backend "{}".'.format(K.backend()))
 
 
-def GeneralizedAdvantageEstimator(critic, state, reward, gamma, lamb):
-    # TODO: we still need to fix an interface
+def GeneralizedAdvantageEstimator(critic, state_batch, reward, gamma, lamb):
     # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
-    assert len(state) == len(reward)
-    n = len(state)
-    value = critic.predict_on_batch(state).flatten()
+    #
+    # state_batch: a numpy array of batched input that can be feed into the critic network directly
+    # reward: numpy array of shape (batch_size,)
+    n = len(state_batch)
+    assert reward.shape == (n,)
+    value = critic.predict_on_batch(state_batch).flatten()
     delta = reward + gamma * np.roll(value, -1) - value
     # No premature optimization for now...
     result = [0]

--- a/rl/util.py
+++ b/rl/util.py
@@ -85,17 +85,17 @@ def huber_loss(y_true, y_pred, clip_value):
 
 
 def GeneralizedAdvantageEstimator(critic, state, reward, gamma, lamb):
-    # TODO: irresponsible draft, all details likely wrong
+    # TODO: we still need to fix an interface
     # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
     assert len(state) == len(reward)
     n = len(state)
-    value = critic.predict_on_batch(np.array(state)).flatten()
-    delta = reward + gamma * np.roll(value, 1) - value
+    value = critic.predict_on_batch(state).flatten()
+    delta = reward + gamma * np.roll(value, -1) - value
     # No premature optimization for now...
     result = [0]
     r = gamma * lamb
-    for i in range(0, n):
-        result.append(result[-1] * r + delta[n-i])
+    for i in range(1, n):
+        result.append(result[-1] * r + delta[n-1-i])
     return result[:0:-1]
 
 

--- a/rl/util.py
+++ b/rl/util.py
@@ -85,11 +85,18 @@ def huber_loss(y_true, y_pred, clip_value):
 
 
 def GeneralizedAdvantageEstimator(critic, state_batch, reward, gamma, lamb):
-    # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
-    #
-    # state_batch: a numpy array of batched input that can be feed into the critic network directly
-    #  note that it must also contain the ending state, i.e. has batch_size + 1 entries
-    # reward: numpy array of shape (batch_size,)
+    """
+    Compute the Generalized Advantage Estimator.
+
+    See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
+
+    :param critic: Critic network.
+    :param state_batch: A numpy array of batched input that can be feed into the critic network directly. Note that it must also contain the ending state, i.e. has batch_size + 1 entries.
+    :param reward: numpy array of shape (batch_size,)
+    :param gamma: Tuning parameter gamma.
+    :param lamb: Tuning parameter lambda.
+    :return: Python List of GAE values in ascending time order (matched with parameter reward)
+    """
     n = len(state_batch) - 1
     assert reward.shape == (n,)
     value = critic.predict_on_batch(state_batch).flatten()

--- a/rl/util.py
+++ b/rl/util.py
@@ -83,6 +83,7 @@ def huber_loss(y_true, y_pred, clip_value):
     else:
         raise RuntimeError('Unknown backend "{}".'.format(K.backend()))
 
+
 def GeneralizedAdvantageEstimator(critic, state, reward, gamma, lamb):
     # TODO: irresponsible draft, all details likely wrong
     # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
@@ -96,6 +97,7 @@ def GeneralizedAdvantageEstimator(critic, state, reward, gamma, lamb):
     for i in range(0, n):
         result.append(result[-1] * r + delta[n-i])
     return result[:0:-1]
+
 
 class AdditionalUpdatesOptimizer(optimizers.Optimizer):
     def __init__(self, optimizer, additional_updates):

--- a/rl/util.py
+++ b/rl/util.py
@@ -83,6 +83,19 @@ def huber_loss(y_true, y_pred, clip_value):
     else:
         raise RuntimeError('Unknown backend "{}".'.format(K.backend()))
 
+def GeneralizedAdvantageEstimator(critic, state, reward, gamma, lamb):
+    # TODO: irresponsible draft, all details likely wrong
+    # See https://danieltakeshi.github.io/2017/04/02/notes-on-the-generalized-advantage-estimation-paper/
+    assert len(state) == len(reward)
+    n = len(state)
+    value = critic.predict_on_batch(np.array(state)).flatten()
+    delta = reward + gamma * np.roll(value, 1) - value
+    # No premature optimization for now...
+    result = [0]
+    r = gamma * lamb
+    for i in range(0, n):
+        result.append(result[-1] * r + delta[n-i])
+    return result[:0:-1]
 
 class AdditionalUpdatesOptimizer(optimizers.Optimizer):
     def __init__(self, optimizer, additional_updates):

--- a/tests/rl/agents/test_ppo.py
+++ b/tests/rl/agents/test_ppo.py
@@ -1,0 +1,56 @@
+from __future__ import division
+from __future__ import absolute_import
+
+import pytest
+import numpy as np
+import gym
+
+import keras.backend as K
+
+from keras.models import Sequential, Model
+from keras.layers import Dense, Activation, Flatten, Input, merge
+
+from rl.agents.ppo import PPOAgent
+from rl.memory import SequentialMemory
+
+from rl.random import IndependentGaussianProcess
+
+# from https://github.com/MorvanZhou/train-robot-arm-from-scratch
+# redacted until libre license confirmed (or alternative found)
+
+def test_ppo_basic():
+    env = ArmEnv()
+    critic = Sequential()
+    critic.add(Flatten(input_shape=(3, 9)))
+    critic.add(Dense(32))
+    critic.add(Activation('relu'))
+    critic.add(Dense(32))
+    critic.add(Activation('relu'))
+    critic.add(Dense(32))
+    critic.add(Activation('relu'))
+    critic.add(Dense(1))
+    critic.add(Activation('linear'))
+
+    c = Input(name='dummy', tensor=K.constant(np.array([[1.0]])), shape=(1,))
+    test_sigma = Dense(2, use_bias=False)
+    out_s = test_sigma(c)
+
+    actor_in = Input(name='actual', shape=(3, 9))
+    f_ac_in = Flatten()(actor_in)
+
+    x = Dense(32, activation='relu')(f_ac_in)
+    x = Dense(64, activation='relu')(x)
+    x = Dense(16, activation='relu')(x)
+    ac_out = Dense(2, activation='linear')(x)
+
+    actor = Model(inputs=[c, actor_in], outputs=[ac_out, out_s])
+
+    sampler = IndependentGaussianProcess(2)
+    memory = SequentialMemory(limit=10, window_length=3)
+
+    agent = PPOAgent(actor, 1, critic, memory, sampler)
+    agent.compile('sgd')
+    agent.fit(env, nb_steps=20)
+
+#if __name__ == "__main__":
+#    test_ppo_basic()

--- a/tests/rl/test_random.py
+++ b/tests/rl/test_random.py
@@ -1,19 +1,21 @@
 import pytest
 import numpy as np
 from rl.random import IndependentGaussianProcess
+from numpy.testing import assert_allclose
 
 from keras import backend as K
 
 def test_gaussian():
     test_mu = np.array([ [0.0, 1.0], [1.0, 0.0], [-1.0, 2.0] ])
-    test_sigma = np.array([ [2.0, 3.0], [4.0, 5.0], [ 6.0, 0.0] ])
+    test_sigma = np.log(np.array([ [2.0, 3.0], [4.0, 5.0], [ 6.0, 0.0] ]))
     test_in = np.array([ [0.0 + 2.0 * 1, 1.0 - 3.0 * 2],
                          [1.0 + 4.0 * 0, 0.0 - 5.0 * 0.5],
                          [-1.0 + 6.0 * 1.5, 2.0] ])
     test_data = (K.constant(test_mu), K.constant(test_sigma), K.constant(test_in))
     p = IndependentGaussianProcess(2)
-    result = p.get_dist(test_data)
-    assert False, K.eval(result)
+    result = K.eval(p.get_dist(test_data))
+    assert result.shape == (3, 1)
+    assert_allclose(result, np.array([ [-6.12964], [-4.95861], [np.nan] ]), equal_nan=True, atol=1e-5)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/rl/test_random.py
+++ b/tests/rl/test_random.py
@@ -1,0 +1,19 @@
+import pytest
+import numpy as np
+from rl.random import IndependentGaussianProcess
+
+from keras import backend as K
+
+def test_gaussian():
+    test_mu = np.array([ [0.0, 1.0], [1.0, 0.0], [-1.0, 2.0] ])
+    test_sigma = np.array([ [2.0, 3.0], [4.0, 5.0], [ 6.0, 0.0] ])
+    test_in = np.array([ [0.0 + 2.0 * 1, 1.0 - 3.0 * 2],
+                         [1.0 + 4.0 * 0, 0.0 - 5.0 * 0.5],
+                         [-1.0 + 6.0 * 1.5, 2.0] ])
+    test_data = (K.constant(test_mu), K.constant(test_sigma), K.constant(test_in))
+    p = IndependentGaussianProcess(2)
+    result = p.get_dist(test_data)
+    assert False, K.eval(result)
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/rl/test_util.py
+++ b/tests/rl/test_util.py
@@ -81,7 +81,7 @@ def test_generalized_advantage_estimator():
     test_reward = np.array([ -14.2, -11.9, -10.5, -10.7, -3.8 ])
     assert_allclose(value_net.predict_on_batch(np.array([[3.0, 4.0]])), np.array([[-25.0]]))
     result = GeneralizedAdvantageEstimator(value_net, test_states, test_reward, 0.9, 0.5)
-    assert False, result
+    assert_allclose(result, np.array([-11.817766, -9.141702, -4.499338, -1.120750, -2.475000]), atol=1e-5)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Hi everyone,

This is my first PR (and a big one relatively speaking) implementing PPO Agent. Due to limitation with keras-rl's current architecture (and not wanting to change it without first discussing and gaining consensus from the community), this version is synchronous instead of the full A3C one. Generalized Advantage Estimator and the clipped surrogate objective are included, but not the adaptive KL penalty.

This implementation intents to support actor network with dummy input and (by necessity with how PPO works) action generated according to a specified probability distribution. The dummy input part is useful to incorporate parameters of the probability distribution into the network so that they too can be tuned.

I'm now in the integration testing stage, where I will try to iteratively discover and resolve remaining bugs/issues with the codes. The current problem I'm looking at is that for the original actor network, once all the rituals are done right, you can skip supplying the values for the dummy inputs during evaluation/prediction (even though the inputs list for the model must still include it). However after cloning the actor this doesn't work anymore.

For maintainer/merger/reviewer:

Because this branch diverged/originated a pretty long time ago, I would suggest having a parallel branch on the main repo and merge into that first. Especially considering all the changes/updates in dependency version (keras main for example), re-org, that kind of stuff that's been on-going and accelerating recently.

Thanks!
