### PR TITLE
Prioritized Experience Replay

### DIFF
--- a/docs/sources/agents/dqn.md
+++ b/docs/sources/agents/dqn.md
@@ -19,3 +19,4 @@ Write me
 - [Human-level control through deep reinforcement learning](http://www.nature.com/nature/journal/v518/n7540/abs/nature14236.html), Mnih et al., 2015
 - [Deep Reinforcement Learning with Double Q-learning](http://www0.cs.ucl.ac.uk/staff/d.silver/web/Applications_files/doubledqn.pdf), van Hasselt et al., 2015
 - [Dueling Network Architectures for Deep Reinforcement Learning](https://arxiv.org/abs/1511.06581), Wang et al., 2016
+- [Prioritized Experience Replay](https://arxiv.org/abs/1511.05952?context=cs), Schaul et al., 2016

--- a/examples/dqn_atari.py
+++ b/examples/dqn_atari.py
@@ -1,25 +1,23 @@
 from __future__ import division
 import argparse
-
 from PIL import Image
 import numpy as np
 import gym
 
-from keras.models import Sequential
-from keras.layers import Dense, Activation, Flatten, Convolution2D, Permute
+from keras.models import Model
+from keras.layers import Dense, Flatten, Convolution2D, Input
 from keras.optimizers import Adam
 import keras.backend as K
 
 from rl.agents.dqn import DQNAgent
 from rl.policy import LinearAnnealedPolicy, BoltzmannQPolicy, EpsGreedyQPolicy
-from rl.memory import SequentialMemory
+from rl.memory import SequentialMemory, PrioritizedMemory
 from rl.core import Processor
 from rl.callbacks import FileLogger, ModelIntervalCheckpoint
 
 
 INPUT_SHAPE = (84, 84)
 WINDOW_LENGTH = 4
-
 
 class AtariProcessor(Processor):
     def process_observation(self, observation):
@@ -53,32 +51,22 @@ env.seed(123)
 nb_actions = env.action_space.n
 
 # Next, we build our model. We use the same model that was described by Mnih et al. (2015).
-input_shape = (WINDOW_LENGTH,) + INPUT_SHAPE
-model = Sequential()
-if K.image_dim_ordering() == 'tf':
-    # (width, height, channels)
-    model.add(Permute((2, 3, 1), input_shape=input_shape))
-elif K.image_dim_ordering() == 'th':
-    # (channels, width, height)
-    model.add(Permute((1, 2, 3), input_shape=input_shape))
-else:
-    raise RuntimeError('Unknown image_dim_ordering.')
-model.add(Convolution2D(32, 8, 8, subsample=(4, 4)))
-model.add(Activation('relu'))
-model.add(Convolution2D(64, 4, 4, subsample=(2, 2)))
-model.add(Activation('relu'))
-model.add(Convolution2D(64, 3, 3, subsample=(1, 1)))
-model.add(Activation('relu'))
-model.add(Flatten())
-model.add(Dense(512))
-model.add(Activation('relu'))
-model.add(Dense(nb_actions))
-model.add(Activation('linear'))
+input_shape = (WINDOW_LENGTH, INPUT_SHAPE[0], INPUT_SHAPE[1])
+frame = Input(shape=(input_shape))
+cv1 = Convolution2D(32, kernel_size=(8,8), strides=4, activation='relu', data_format='channels_first')(frame)
+cv2 = Convolution2D(64, kernel_size=(4,4), strides=2, activation='relu', data_format='channels_first')(cv1)
+cv3 = Convolution2D(64, kernel_size=(3,3), strides=1, activation='relu', data_format='channels_first')(cv2)
+dense= Flatten()(cv3)
+dense = Dense(512, activation='relu')(dense)
+buttons = Dense(nb_actions, activation='linear')(dense)
+model = Model(inputs=frame,outputs=buttons)
 print(model.summary())
 
 # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
 # even the metrics!
-memory = SequentialMemory(limit=1000000, window_length=WINDOW_LENGTH)
+
+#memory = SequentialMemory(limit=1000000, window_length=WINDOW_LENGTH)
+memory = PrioritizedMemory(limit=1000000, alpha=.6, start_beta=.4, end_beta=1., steps_annealed=1700000, window_length=WINDOW_LENGTH)
 processor = AtariProcessor()
 
 # Select a policy. We use eps-greedy action selection, which means that a random action is selected
@@ -87,7 +75,7 @@ processor = AtariProcessor()
 # (low eps). We also set a dedicated eps value that is used during testing. Note that we set it to 0.05
 # so that the agent still performs some random actions. This ensures that the agent cannot get stuck.
 policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., value_min=.1, value_test=.05,
-                              nb_steps=1000000)
+                              nb_steps=750000)
 
 # The trade-off between exploration and exploitation is difficult and an on-going research topic.
 # If you want, you can experiment with the parameters or use a different policy. Another popular one
@@ -96,9 +84,12 @@ policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., valu
 # Feel free to give it a try!
 
 dqn = DQNAgent(model=model, nb_actions=nb_actions, policy=policy, memory=memory,
-               processor=processor, nb_steps_warmup=50000, gamma=.99, target_model_update=10000,
+               processor=processor, enable_double_dqn=True, enable_dueling_network=True, nb_steps_warmup=50000, gamma=.99, target_model_update=10000,
                train_interval=4, delta_clip=1.)
-dqn.compile(Adam(lr=.00025), metrics=['mae'])
+lr = .00025
+if type(memory) == PrioritizedMemory:
+    lr /= 4
+dqn.compile(Adam(lr=lr), metrics=['mae'])
 
 if args.mode == 'train':
     # Okay, now it's time to learn something! We capture the interrupt exception so that training
@@ -108,7 +99,7 @@ if args.mode == 'train':
     log_filename = 'dqn_{}_log.json'.format(args.env_name)
     callbacks = [ModelIntervalCheckpoint(checkpoint_weights_filename, interval=250000)]
     callbacks += [FileLogger(log_filename, interval=100)]
-    dqn.fit(env, callbacks=callbacks, nb_steps=1750000, log_interval=10000)
+    dqn.fit(env, callbacks=callbacks, nb_steps=2000000, log_interval=10000)
 
     # After training is done, we save the final weights one more time.
     dqn.save_weights(weights_filename, overwrite=True)


### PR DESCRIPTION
An implementation of [Prioritized Experience Replay](https://arxiv.org/abs/1511.05952?context=cs), Schaul et al., 2016.

Key features/changes:

dqn.py: Adds logic to determine if the memory is Prioritized, and adjusts the algorithm accordingly. I've run a few tests and things seem to be working, but I'd appreciate some help looking over the math.

memory.py: Adds PrioritizedMemory, which samples experiences proportional to their TD error. Uses similar conventions to SequentialMemory.

util.py: Adds segment tree data structure used by PrioritizedMemory, which is taken almost directly from the [OpenAI baseline version](https://github.com/openai/baselines/blob/master/baselines/common/segment_tree.py).

dqn_atari.py: Modifies the dqn example to include PrioritizedMemory (Sequential is still there but commented out). Also changes the keras model to the functional api, as well as updates the Convolution2D syntax (no more deprecation warnings).

docs/dqn.md: Adds the PER paper to the references.

I've done a handful of 8 million + time step training runs as tests (on Breakout v0 and v4). Learning went smoothly. Unfortunately, there was a bug that prevented the memory's beta value from annealing properly, so I can't say for sure that it's working. That's been fixed and I'm starting a new 10 mil run. As of 2.6m everything is still going well so I think this is good enough to put up for review; I'll comment the results when it's complete.