### PR TITLE
dqfd, noisynet + PER fix

### DIFF
--- a/docs/sources/agents/dqn.md
+++ b/docs/sources/agents/dqn.md
@@ -19,3 +19,4 @@ Write me
 - [Human-level control through deep reinforcement learning](http://www.nature.com/nature/journal/v518/n7540/abs/nature14236.html), Mnih et al., 2015
 - [Deep Reinforcement Learning with Double Q-learning](http://www0.cs.ucl.ac.uk/staff/d.silver/web/Applications_files/doubledqn.pdf), van Hasselt et al., 2015
 - [Dueling Network Architectures for Deep Reinforcement Learning](https://arxiv.org/abs/1511.06581), Wang et al., 2016
+- [Prioritized Experience Replay](https://arxiv.org/abs/1511.05952?context=cs), Schaul et al., 2016

--- a/docs/sources/agents/dqn.md
+++ b/docs/sources/agents/dqn.md
@@ -20,3 +20,4 @@ Write me
 - [Deep Reinforcement Learning with Double Q-learning](http://www0.cs.ucl.ac.uk/staff/d.silver/web/Applications_files/doubledqn.pdf), van Hasselt et al., 2015
 - [Dueling Network Architectures for Deep Reinforcement Learning](https://arxiv.org/abs/1511.06581), Wang et al., 2016
 - [Prioritized Experience Replay](https://arxiv.org/abs/1511.05952?context=cs), Schaul et al., 2016
+- [Deep Q-learning from Demonstrations](https://arxiv.org/pdf/1704.03732.pdf), Hester et al., 2017

--- a/examples/dqfd_atari.py
+++ b/examples/dqfd_atari.py
@@ -68,10 +68,12 @@ dense= Flatten()(cv3)
 dense = Dense(512, activation='relu', kernel_regularizer=l2(1e-4))(dense)
 buttons = Dense(nb_actions, activation='linear', kernel_regularizer=l2(1e-4))(dense)
 model = Model(inputs=frame,outputs=buttons)
-print(model.summary())
+model.summary()
 
 processor = AtariDQfDProcessor()
+
 # record_demo_data('GopherDeterministic-v4', steps=50000, data_filepath='gopher_expert.npy', frame_delay=0.03)
+
 # Load and process the demonstration data.
 expert_demo_data = processor.process_demo_data(load_demo_data_from_file('gopher_expert.npy'))
 memory = PartitionedMemory(limit=1000000, pre_load_data=expert_demo_data, alpha=.4, start_beta=.6, end_beta=.6, window_length=WINDOW_LENGTH)

--- a/examples/dqfd_atari.py
+++ b/examples/dqfd_atari.py
@@ -8,7 +8,7 @@ from keras.layers import Flatten, Conv2D, Input, Dense
 from keras.optimizers import Adam
 from keras.regularizers import l2
 import keras.backend as K
-from rl.agents.dqfd import DQfDAgent
+from rl.agents.dqn import DQfDAgent
 from rl.policy import LinearAnnealedPolicy, EpsGreedyQPolicy
 from rl.memory import PartitionedMemory
 from rl.core import Processor

--- a/examples/dqn_atari.py
+++ b/examples/dqn_atari.py
@@ -1,25 +1,23 @@
 from __future__ import division
 import argparse
-
 from PIL import Image
 import numpy as np
 import gym
 
-from keras.models import Sequential
-from keras.layers import Dense, Activation, Flatten, Convolution2D, Permute
+from keras.models import Model
+from keras.layers import Dense, Flatten, Convolution2D, Input
 from keras.optimizers import Adam
 import keras.backend as K
 
 from rl.agents.dqn import DQNAgent
 from rl.policy import LinearAnnealedPolicy, BoltzmannQPolicy, EpsGreedyQPolicy
-from rl.memory import SequentialMemory
+from rl.memory import SequentialMemory, PrioritizedMemory
 from rl.core import Processor
 from rl.callbacks import FileLogger, ModelIntervalCheckpoint
 
 
 INPUT_SHAPE = (84, 84)
 WINDOW_LENGTH = 4
-
 
 class AtariProcessor(Processor):
     def process_observation(self, observation):
@@ -53,32 +51,22 @@ env.seed(123)
 nb_actions = env.action_space.n
 
 # Next, we build our model. We use the same model that was described by Mnih et al. (2015).
-input_shape = (WINDOW_LENGTH,) + INPUT_SHAPE
-model = Sequential()
-if K.image_dim_ordering() == 'tf':
-    # (width, height, channels)
-    model.add(Permute((2, 3, 1), input_shape=input_shape))
-elif K.image_dim_ordering() == 'th':
-    # (channels, width, height)
-    model.add(Permute((1, 2, 3), input_shape=input_shape))
-else:
-    raise RuntimeError('Unknown image_dim_ordering.')
-model.add(Convolution2D(32, 8, 8, subsample=(4, 4)))
-model.add(Activation('relu'))
-model.add(Convolution2D(64, 4, 4, subsample=(2, 2)))
-model.add(Activation('relu'))
-model.add(Convolution2D(64, 3, 3, subsample=(1, 1)))
-model.add(Activation('relu'))
-model.add(Flatten())
-model.add(Dense(512))
-model.add(Activation('relu'))
-model.add(Dense(nb_actions))
-model.add(Activation('linear'))
+input_shape = (WINDOW_LENGTH, INPUT_SHAPE[0], INPUT_SHAPE[1])
+frame = Input(shape=(input_shape))
+cv1 = Convolution2D(32, kernel_size=(8,8), strides=4, activation='relu', data_format='channels_first')(frame)
+cv2 = Convolution2D(64, kernel_size=(4,4), strides=2, activation='relu', data_format='channels_first')(cv1)
+cv3 = Convolution2D(64, kernel_size=(3,3), strides=1, activation='relu', data_format='channels_first')(cv2)
+dense= Flatten()(cv3)
+dense = Dense(512, activation='relu')(dense)
+buttons = Dense(nb_actions, activation='linear')(dense)
+model = Model(inputs=frame,outputs=buttons)
 print(model.summary())
 
 # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
 # even the metrics!
-memory = SequentialMemory(limit=1000000, window_length=WINDOW_LENGTH)
+
+#memory = SequentialMemory(limit=1000000, window_length=WINDOW_LENGTH)
+memory = PrioritizedMemory(limit=1000000, alpha=.6, start_beta=.4, end_beta=1., steps_annealed=1700000, window_length=WINDOW_LENGTH)
 processor = AtariProcessor()
 
 # Select a policy. We use eps-greedy action selection, which means that a random action is selected
@@ -87,7 +75,7 @@ processor = AtariProcessor()
 # (low eps). We also set a dedicated eps value that is used during testing. Note that we set it to 0.05
 # so that the agent still performs some random actions. This ensures that the agent cannot get stuck.
 policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., value_min=.1, value_test=.05,
-                              nb_steps=1000000)
+                              nb_steps=750000)
 
 # The trade-off between exploration and exploitation is difficult and an on-going research topic.
 # If you want, you can experiment with the parameters or use a different policy. Another popular one
@@ -96,9 +84,12 @@ policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., valu
 # Feel free to give it a try!
 
 dqn = DQNAgent(model=model, nb_actions=nb_actions, policy=policy, memory=memory,
-               processor=processor, nb_steps_warmup=50000, gamma=.99, target_model_update=10000,
+               processor=processor, enable_double_dqn=True, enable_dueling_network=True, nb_steps_warmup=50000, gamma=.99, target_model_update=10000,
                train_interval=4, delta_clip=1.)
-dqn.compile(Adam(lr=.00025), metrics=['mae'])
+lr = .00025
+if type(memory) == PrioritizedMemory:
+    lr /= 4
+dqn.compile(Adam(lr=lr), metrics=['mae'])
 
 if args.mode == 'train':
     # Okay, now it's time to learn something! We capture the interrupt exception so that training
@@ -108,7 +99,7 @@ if args.mode == 'train':
     log_filename = 'dqn_{}_log.json'.format(args.env_name)
     callbacks = [ModelIntervalCheckpoint(checkpoint_weights_filename, interval=250000)]
     callbacks += [FileLogger(log_filename, interval=100)]
-    dqn.fit(env, callbacks=callbacks, nb_steps=1750000, log_interval=10000)
+    dqn.fit(env, callbacks=callbacks, nb_steps=2000000, log_interval=10000)
 
     # After training is done, we save the final weights one more time.
     dqn.save_weights(weights_filename, overwrite=True)

--- a/examples/noisynet_pdd_dqn_atari.py
+++ b/examples/noisynet_pdd_dqn_atari.py
@@ -9,7 +9,7 @@ from keras.optimizers import Adam
 import keras.backend as K
 from rl.agents.dqn import DQNAgent
 from rl.policy import GreedyQPolicy
-from rl.memory import PrioritizedMemory #,Sequential
+from rl.memory import PrioritizedMemory
 from rl.core import Processor
 from rl.callbacks import TrainEpisodeLogger, ModelIntervalCheckpoint
 from rl.layers import NoisyNetDense
@@ -59,7 +59,7 @@ dense= Flatten()(cv3)
 dense = NoisyNetDense(512, activation='relu')(dense)
 buttons = NoisyNetDense(nb_actions, activation='linear')(dense)
 model = Model(inputs=frame,outputs=buttons)
-print(model.summary())
+model.summary()
 
 #You can use any Memory you want.
 memory = PrioritizedMemory(limit=1000000, alpha=.6, start_beta=.4, end_beta=1., steps_annealed=10000000, window_length=WINDOW_LENGTH)
@@ -73,7 +73,7 @@ policy = GreedyQPolicy()
 
 dqn = DQNAgent(model=model, nb_actions=nb_actions, policy=policy, memory=memory,
                processor=processor, enable_double_dqn=True, enable_dueling_network=True, nb_steps_warmup=50000, gamma=.99, target_model_update=10000,
-               train_interval=4, delta_clip=1.)
+               train_interval=4, delta_clip=1., custom_model_objects={"NoisyNetDense":NoisyNetDense})
 
 #Prioritized Memories typically use lower learning rates
 lr = .00025
@@ -93,7 +93,7 @@ if args.mode == 'train':
     dqn.save_weights(weights_filename, overwrite=True)
 
 elif args.mode == 'test':
-    weights_filename = 'noiseynet_pdd_dqn_{}_weights.h5f'.format(args.env_name)
+    weights_filename = 'noisynet_pdd_dqn_{}_weights.h5f'.format(args.env_name)
     if args.weights:
         weights_filename = args.weights
     dqn.load_weights(weights_filename)

--- a/examples/noisynet_pdd_dqn_atari.py
+++ b/examples/noisynet_pdd_dqn_atari.py
@@ -77,7 +77,7 @@ dqn = DQNAgent(model=model, nb_actions=nb_actions, policy=policy, memory=memory,
 
 #Prioritized Memories typically use lower learning rates
 lr = .00025
-if type(memory) == PrioritizedMemory:
+if isinstance(memory, PrioritizedMemory):
     lr /= 4
 dqn.compile(Adam(lr=lr), metrics=['mae'])
 

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -129,7 +129,7 @@ class DQNAgent(AbstractDQNAgent):
             # y[:,0] represents V(s;theta)
             # y[:,1:] represents A(s,a;theta)
             y = Dense(nb_action + 1, activation='linear')(layer.output)
-            if type(layer) == NoisyNetDense:
+            if isinstance(layer, NoisyNetDense):
                 y = NoisyNetDense(nb_action + 1, activation='linear')(layer.output)
             # caculate the Q(s,a;theta)
             # dueling_type == 'avg'
@@ -656,7 +656,7 @@ class DQfDAgent(AbstractDQNAgent):
             nb_action = model.output._keras_shape[-1]
             y = Dense(nb_action + 1, activation='linear')(layer.output)
             #preserve use of noisy nets.
-            if type(layer) == NoisyNetDense:
+            if isinstance(layer, NoisyNetDense):
                 y = NoisyNetDense(nb_action + 1, activation='linear')(layer.output)
             # options for dual-stream merger
             if self.dueling_type == 'avg':
@@ -792,8 +792,8 @@ class DQfDAgent(AbstractDQNAgent):
             current_beta = self.memory.calculate_beta(self.step)
             # Sample from the memory.
             idxs = self.memory.sample_proportional(self.batch_size)
-            experiences_n = self.memory.sample(idxs, self.batch_size, current_beta, self.n_step, self.gamma)
-            experiences = self.memory.sample(idxs, self.batch_size, current_beta)
+            experiences_n = self.memory.sample_by_idxs(idxs, self.batch_size, current_beta, self.n_step, self.gamma)
+            experiences = self.memory.sample_by_idxs(idxs, self.batch_size, current_beta)
 
             # Start by extracting the necessary parameters (we use a vectorized implementation).
             state0_batch = []
@@ -949,7 +949,7 @@ class DQfDAgent(AbstractDQNAgent):
         return metrics
 
     def get_config(self):
-        config = super(DQNAgent, self).get_config()
+        config = super(DQfDAgent, self).get_config()
         config['enable_double_dqn'] = self.enable_double_dqn
         config['dueling_type'] = self.dueling_type
         config['enable_dueling_network'] = self.enable_dueling_network

--- a/rl/layers.py
+++ b/rl/layers.py
@@ -27,10 +27,12 @@ class NoisyNetDense(Layer):
                 **kwargs):
 
         super(NoisyNetDense, self).__init__(**kwargs)
+
         self.units = units
+
         self.activation = activations.get(activation)
         self.kernel_constraint = constraints.get(kernel_constraint) if kernel_constraint is not None else None
-        self.bias_constraint = constriants.get(bias_constraint)if kernel_constraint is not None else None
+        self.bias_constraint = constraints.get(bias_constraint) if kernel_constraint is not None else None
         self.kernel_regularizer = regularizers.get(kernel_regularizer)if kernel_constraint is not None else None
         self.bias_regularizer = regularizers.get(bias_regularizer) if kernel_constraint is not None else None
 

--- a/rl/layers.py
+++ b/rl/layers.py
@@ -111,7 +111,7 @@ class NAFLayer(Layer):
     """
     def __init__(self, nb_actions, mode='full', **kwargs):
         if mode not in ('full', 'diag'):
-            raise RuntimeError('Unknown mode "{}" in NAFLayer.'.format(self.mode))
+            raise RuntimeError('Unknown mode "{}" in NAFLayer.'.format(mode))
 
         self.nb_actions = nb_actions
         self.mode = mode
@@ -281,7 +281,7 @@ class NAFLayer(Layer):
             expected_elements = None
         assert expected_elements is not None
         if input_shape[0][1] != expected_elements:
-            raise RuntimeError("Input 0 (L) should have {} elements but has {}".format(input_shape[0][1]))
+            raise RuntimeError("Input 0 (L) should have {} elements but has {}".format(expected_elements, input_shape[0][1]))
         if input_shape[1][1] != self.nb_actions:
             raise RuntimeError(
                 "Input 1 (mu) should have {} elements but has {}".format(self.nb_actions, input_shape[1][1]))

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -611,7 +611,7 @@ class PartitionedMemory(Memory):
 
         return idxs
 
-    def sample(self, idxs, batch_size, beta=1., nstep=1, gamma=1):
+    def sample_by_idxs(self, idxs, batch_size, beta=1., nstep=1, gamma=1):
         """
         Gathers transition data from the ring buffers. The PartitionedMemory
         separates generating the idxs and returning their transitions, allowing
@@ -718,7 +718,7 @@ class PartitionedMemory(Memory):
         return current_beta
 
     def get_config(self):
-        config = super(PrioritizedMemory, self).get_config()
+        config = super(PartitionedMemory, self).get_config()
         config['alpha'] = self.alpha
         config['start_beta'] = self.start_beta
         config['end_beta'] = self.end_beta

--- a/rl/util.py
+++ b/rl/util.py
@@ -287,15 +287,14 @@ def record_demo_data(env_name, steps, frame_delay=0.03, env_seed=123, data_filep
     print("No keys pressed is taking action 0")
 
     transitions = []
-    obser = env.reset()
-    total_reward = 0
+    _ = env.reset()
     total_timesteps = 0
 
     while total_timesteps < steps:
         if total_timesteps % 1000 == 0:
             print("Steps Elapsed: " + str(total_timesteps))
         act = action
-        obs, r, done, info = env.step(act)
+        obs, r, done, _ = env.step(act)
         transitions.append([obs, act, r, done])
         total_timesteps += 1
         env.render(mode='human')

--- a/rl/util.py
+++ b/rl/util.py
@@ -286,16 +286,20 @@ def record_demo_data(env_name, steps, frame_delay=0.03, env_seed=123, data_filep
     print("Press keys 1 2 3 ... to take actions 1 2 3 ...")
     print("No keys pressed is taking action 0")
 
-    transitions = []
-    _ = env.reset()
+    experiences = []
+    obs = env.reset()
     total_timesteps = 0
 
     while total_timesteps < steps:
         if total_timesteps % 1000 == 0:
             print("Steps Elapsed: " + str(total_timesteps))
+        transition = [obs]
         act = action
+        transition.append(act)
         obs, r, done, _ = env.step(act)
-        transitions.append([obs, act, r, done])
+        transition.append(r)
+        transition.append(done)
+        experiences.append(transition)
         total_timesteps += 1
         env.render(mode='human')
         if done:
@@ -309,7 +313,7 @@ def record_demo_data(env_name, steps, frame_delay=0.03, env_seed=123, data_filep
         #Gym runs the environments fast by default. Tweak the frame_delay parameter to adjust play speed.
         time.sleep(frame_delay)
 
-    data_matrix = np.array(transitions)
+    data_matrix = np.array(experiences)
     np.save(data_filepath, data_matrix)
 
 def load_demo_data_from_file(data_filepath='expert_demo_data.npy'):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(name='keras-rl',
       author='Matthias Plappert',
       author_email='matthiasplappert@me.com',
       url='https://github.com/keras-rl/keras-rl',
-      download_url='https://github.com/keras-rl/keras-rl/archive/v0.4.0.tar.gz',
       license='MIT',
       install_requires=['keras>=2.0.7'],
       extras_require={

--- a/tests/rl/agents/test_dqn.py
+++ b/tests/rl/agents/test_dqn.py
@@ -8,9 +8,9 @@ from numpy.testing import assert_allclose
 from keras.models import Sequential, Model
 from keras.layers import Input, Dense, Flatten, Concatenate
 
-from rl.agents.dqn import DQNAgent, NAFAgent
+from rl.agents.dqn import DQNAgent, NAFAgent, DQfDAgent
 from rl.layers import *
-from rl.memory import SequentialMemory
+from rl.memory import SequentialMemory, PartitionedMemory
 from rl.processors import MultiInputProcessor
 
 from ..util import MultiInputTestEnv
@@ -28,6 +28,16 @@ def test_single_dqn_input():
         agent.compile('sgd')
         agent.fit(MultiInputTestEnv((3,)), nb_steps=10)
 
+def test_single_dqfd_input():
+    model = Sequential()
+    model.add(Flatten(input_shape=(2, 3)))
+    model.add(Dense(2))
+    pre_load_data = np.array([[np.random.rand(3),1,2,False] for i in range(20)])
+    memory = PartitionedMemory(limit=40, pre_load_data=pre_load_data, window_length=2)
+    dqfd = DQfDAgent(model, nb_actions=2, memory=memory, enable_double_dqn=True,
+                    pretraining_steps=20, batch_size=4, n_step=3)
+    dqfd.compile('sgd')
+    dqfd.fit(MultiInputTestEnv((3,)), nb_steps=10)
 
 def test_multi_dqn_input():
     input1 = Input(shape=(2, 3))

--- a/tests/rl/agents/test_dqn.py
+++ b/tests/rl/agents/test_dqn.py
@@ -8,7 +8,8 @@ from numpy.testing import assert_allclose
 from keras.models import Sequential, Model
 from keras.layers import Input, Dense, Flatten, Concatenate
 
-from rl.agents.dqn import NAFLayer, DQNAgent, NAFAgent
+from rl.agents.dqn import DQNAgent, NAFAgent
+from rl.layers import *
 from rl.memory import SequentialMemory
 from rl.processors import MultiInputProcessor
 


### PR DESCRIPTION
Key changes:

dqn.py: Adds my attempt at Deep Q Learning from Demonstrations.

memory.py: Adds memory for dqfd, which is a buffer that can sample expert demo data without overwriting it. That includes a custom RingBuffer.

layers.py: New file to hold custom keras layers for our models. adds NoisyNetDense, modeled after [this paper](https://arxiv.org/abs/1706.10295). Also includes NAFLayer, moved over from dqn.py

noisynet_pdd_dqn_atari.py: new example script for training (and testing) a NoisyNet Prioritized Dueling Double DQN. This is separated from the existing dqn_atari example because it requires changes to the keras model itself.

dqfd_atari.py: example that highlights the differences in setting up dqfd vs. dqn.

callbacks.py: adds the option to dump the output of TrainEpisodeLogger into a txt file. Totally optional, but useful if you're used to watching that log output during training and want to see the same stats after completion.

Testing:

<img width="634" alt="noisynet_10m_reward_curve" src="https://user-images.githubusercontent.com/33582737/41383505-12b76754-6f3f-11e8-8943-8866cb9b07dc.png">

This is the learning curve for Noisy PDD DQN on the atari game Gopher. Video of its gameplay [here](https://drive.google.com/open?id=1pCLwEi1aUw0jemQMh9PqcxHsGDk1AtER).



Here is a video of the new noisynet example script playing Boxing, and winning 100-3: [click here](https://drive.google.com/file/d/18crFwEWgTLVbw74ERni2ZrjEtmY609Hl/view?usp=sharing)