### PR TITLE
Potential Bug in 1dConv layer

### DIFF
--- a/conv-dqn.py
+++ b/conv-dqn.py
@@ -1,0 +1,55 @@
+import numpy as np
+import gym
+from my_env import BlockWorldEnvironmentConv
+
+from keras.models import Sequential
+from keras.layers import Dense, Activation, Flatten, Conv1D, Conv2D, Permute
+from keras.optimizers import Adam
+
+from rl.agents.dqn import DQNAgent
+from rl.policy import LinearAnnealedPolicy, BoltzmannQPolicy, EpsGreedyQPolicy
+from rl.memory import SequentialMemory
+
+
+ENV_NAME = 'CartPole-v0'
+
+
+# Get the environment and extract the number of actions.
+env = BlockWorldEnvironmentConv(8, 8, 1, 1, 4, 4)  #gym.make(ENV_NAME)
+np.random.seed(123)
+env.seed(123)
+nb_actions = env.action_space.n
+
+# Next, we build a very simple model.
+model = Sequential()
+model.add(Permute((1, 2), input_shape=(64,) + (1,)))
+model.add(Conv1D(5, filter_length=5, activation='linear', input_shape=(64,) + (1,)))
+model.add(Flatten())
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(4))
+model.add(Activation('linear'))
+print(model.summary())
+
+# Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
+# even the metrics!
+memory = SequentialMemory(limit=50000, window_length=1)
+policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., value_min=.1, value_test=.05,
+nb_steps=1000000)
+dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=10,
+               target_model_update=1e-2, policy=policy)
+dqn.compile(Adam(lr=1e-3), metrics=['mae'])
+# Okay, now it's time to learn something! We visualize the training here for show, but this
+# slows down training quite a lot. You can always safely abort the training prematurely using
+# Ctrl + C.
+dqn.fit(env, nb_steps=50000, verbose=2)
+
+# After training is done, we save the final weights.
+dqn.save_weights('dqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+
+# Finally, evaluate our algorithm for 5 episodes.
+dqn.test(env, nb_episodes=5)

--- a/kerasfix.txt
+++ b/kerasfix.txt
@@ -1,0 +1,211 @@
+in the dqn agent in the agents folder of rl
+
+    def compute_q_values(self, state):
+        q_values = self.compute_batch_q_values([state]).flatten()
+        assert q_values.shape == (self.nb_actions,)
+        return q_values
+
+        should be
+
+    def compute_q_values(self, state):
+        #q_values = self.compute_batch_q_values([state]).flatten()
+        #import pdb; pdb.set_trace()
+        q_values = self.compute_batch_q_values(state).flatten()
+        assert q_values.shape == (self.nb_actions,)
+        return q_values
+
+
+
+    def backward(self, reward, terminal):
+        # Store most recent experience in memory.
+        if self.step % self.memory_interval == 0:
+            self.memory.append(self.recent_observation, self.recent_action, reward, terminal,
+                               training=self.training)
+
+        metrics = [np.nan for _ in self.metrics_names]
+        if not self.training:
+            # We're done here. No need to update the experience memory since we only use the working
+            # memory to obtain the state over the most recent observations.
+            return metrics
+
+        # Train the network on a single stochastic batch.
+        if self.step > self.nb_steps_warmup and self.step % self.train_interval == 0:
+            experiences = self.memory.sample(self.batch_size)
+            assert len(experiences) == self.batch_size
+
+            # Start by extracting the necessary parameters (we use a vectorized implementation).
+            state0_batch = []
+            reward_batch = []
+            action_batch = []
+            terminal1_batch = []
+            state1_batch = []
+            for e in experiences:
+                state0_batch.append(e.state0)
+                state1_batch.append(e.state1)
+                reward_batch.append(e.reward)
+                action_batch.append(e.action)
+                terminal1_batch.append(0. if e.terminal1 else 1.)
+
+            # Prepare and validate parameters.
+            state0_batch = self.process_state_batch(state0_batch)
+            state1_batch = self.process_state_batch(state1_batch)
+            terminal1_batch = np.array(terminal1_batch)
+            reward_batch = np.array(reward_batch)
+            assert reward_batch.shape == (self.batch_size,)
+            assert terminal1_batch.shape == reward_batch.shape
+            assert len(action_batch) == len(reward_batch)
+
+            # Compute Q values for mini-batch update.
+            if self.enable_double_dqn:
+                # According to the paper "Deep Reinforcement Learning with Double Q-learning"
+                # (van Hasselt et al., 2015), in Double DQN, the online network predicts the actions
+                # while the target network is used to estimate the Q value.
+                q_values = self.model.predict_on_batch(state1_batch)
+                assert q_values.shape == (self.batch_size, self.nb_actions)
+                actions = np.argmax(q_values, axis=1)
+                assert actions.shape == (self.batch_size,)
+
+                # Now, estimate Q values using the target network but select the values with the
+                # highest Q value wrt to the online model (as computed above).
+                target_q_values = self.target_model.predict_on_batch(state1_batch)
+                assert target_q_values.shape == (self.batch_size, self.nb_actions)
+                q_batch = target_q_values[range(self.batch_size), actions]
+            else:
+                # Compute the q_values given state1, and extract the maximum for each sample in the batch.
+                # We perform this prediction on the target_model instead of the model for reasons
+                # outlined in Mnih (2015). In short: it makes the algorithm more stable.
+                target_q_values = self.target_model.predict_on_batch(state1_batch)
+                assert target_q_values.shape == (self.batch_size, self.nb_actions)
+                q_batch = np.max(target_q_values, axis=1).flatten()
+            assert q_batch.shape == (self.batch_size,)
+
+            targets = np.zeros((self.batch_size, self.nb_actions))
+            dummy_targets = np.zeros((self.batch_size,))
+            masks = np.zeros((self.batch_size, self.nb_actions))
+
+            # Compute r_t + gamma * max_a Q(s_t+1, a) and update the target targets accordingly,
+            # but only for the affected output units (as given by action_batch).
+            discounted_reward_batch = self.gamma * q_batch
+            # Set discounted reward to zero for all states that were terminal.
+            discounted_reward_batch *= terminal1_batch
+            assert discounted_reward_batch.shape == reward_batch.shape
+            Rs = reward_batch + discounted_reward_batch
+            for idx, (target, mask, R, action) in enumerate(zip(targets, masks, Rs, action_batch)):
+                target[action] = R  # update action with estimated accumulated reward
+                dummy_targets[idx] = R
+                mask[action] = 1.  # enable loss for this specific action
+            targets = np.array(targets).astype('float32')
+            masks = np.array(masks).astype('float32')
+
+            # Finally, perform a single update on the entire batch. We use a dummy target since
+            # the actual loss is computed in a Lambda layer that needs more complex input. However,
+            # it is still useful to know the actual target to compute metrics properly.
+            ins = [state0_batch] if type(self.model.input) is not list else state0_batch
+            metrics = self.trainable_model.train_on_batch(ins + [targets, masks], [dummy_targets, targets])
+            metrics = [metric for idx, metric in enumerate(metrics) if idx not in (1, 2)]  # throw away individual losses
+            metrics += self.policy.metrics
+            if self.processor is not None:
+                metrics += self.processor.metrics
+
+        if self.target_model_update >= 1 and self.step % self.target_model_update == 0:
+            self.update_target_model_hard()
+
+        return metrics
+
+        shoudl be
+
+    def backward(self, reward, terminal):
+        # Store most recent experience in memory.
+        if self.step % self.memory_interval == 0:
+            self.memory.append(self.recent_observation, self.recent_action, reward, terminal,
+                               training=self.training)
+
+        metrics = [np.nan for _ in self.metrics_names]
+        if not self.training:
+            # We're done here. No need to update the experience memory since we only use the working
+            # memory to obtain the state over the most recent observations.
+            return metrics
+
+        # Train the network on a single stochastic batch.
+        if self.step > self.nb_steps_warmup and self.step % self.train_interval == 0:
+            experiences = self.memory.sample(self.batch_size)
+            assert len(experiences) == self.batch_size
+
+            # Start by extracting the necessary parameters (we use a vectorized implementation).
+            state0_batch = []
+            reward_batch = []
+            action_batch = []
+            terminal1_batch = []
+            state1_batch = []
+            #import pdb; pdb.set_trace() RIGHT HERE RIGHT HERE RIGHT HERE
+            for e in experiences:
+                state0_batch.append(e.state0[0])  # modified this
+                state1_batch.append(e.state1[0])  # modified this
+                reward_batch.append(e.reward)
+                action_batch.append(e.action)
+                terminal1_batch.append(0. if e.terminal1 else 1.)
+            # Prepare and validate parameters.
+            state0_batch = self.process_state_batch(state0_batch)
+            state1_batch = self.process_state_batch(state1_batch)
+            terminal1_batch = np.array(terminal1_batch)
+            reward_batch = np.array(reward_batch)
+            assert reward_batch.shape == (self.batch_size,)
+            assert terminal1_batch.shape == reward_batch.shape
+            assert len(action_batch) == len(reward_batch)
+
+            # Compute Q values for mini-batch update.
+            if self.enable_double_dqn:
+                # According to the paper "Deep Reinforcement Learning with Double Q-learning"
+                # (van Hasselt et al., 2015), in Double DQN, the online network predicts the actions
+                # while the target network is used to estimate the Q value.
+                q_values = self.model.predict_on_batch(state1_batch)
+                assert q_values.shape == (self.batch_size, self.nb_actions)
+                actions = np.argmax(q_values, axis=1)
+                assert actions.shape == (self.batch_size,)
+
+                # Now, estimate Q values using the target network but select the values with the
+                # highest Q value wrt to the online model (as computed above).
+                target_q_values = self.target_model.predict_on_batch(state1_batch)
+                assert target_q_values.shape == (self.batch_size, self.nb_actions)
+                q_batch = target_q_values[range(self.batch_size), actions]
+            else:
+                # Compute the q_values given state1, and extract the maximum for each sample in the batch.
+                # We perform this prediction on the target_model instead of the model for reasons
+                # outlined in Mnih (2015). In short: it makes the algorithm more stable.
+                target_q_values = self.target_model.predict_on_batch(state1_batch)
+                assert target_q_values.shape == (self.batch_size, self.nb_actions)
+                q_batch = np.max(target_q_values, axis=1).flatten()
+            assert q_batch.shape == (self.batch_size,)
+
+            targets = np.zeros((self.batch_size, self.nb_actions))
+            dummy_targets = np.zeros((self.batch_size,))
+            masks = np.zeros((self.batch_size, self.nb_actions))
+
+            # Compute r_t + gamma * max_a Q(s_t+1, a) and update the target targets accordingly,
+            # but only for the affected output units (as given by action_batch).
+            discounted_reward_batch = self.gamma * q_batch
+            # Set discounted reward to zero for all states that were terminal.
+            discounted_reward_batch *= terminal1_batch
+            assert discounted_reward_batch.shape == reward_batch.shape
+            Rs = reward_batch + discounted_reward_batch
+            for idx, (target, mask, R, action) in enumerate(zip(targets, masks, Rs, action_batch)):
+                target[action] = R  # update action with estimated accumulated reward
+                dummy_targets[idx] = R
+                mask[action] = 1.  # enable loss for this specific action
+            targets = np.array(targets).astype('float32')
+            masks = np.array(masks).astype('float32')
+
+            # Finally, perform a single update on the entire batch. We use a dummy target since
+            # the actual loss is computed in a Lambda layer that needs more complex input. However,
+            # it is still useful to know the actual target to compute metrics properly.
+            ins = [state0_batch] if type(self.model.input) is not list else state0_batch
+            metrics = self.trainable_model.train_on_batch(ins + [targets, masks], [dummy_targets, targets])
+            metrics = [metric for idx, metric in enumerate(metrics) if idx not in (1, 2)]  # throw away individual losses
+            metrics += self.policy.metrics
+            if self.processor is not None:
+                metrics += self.processor.metrics
+
+        if self.target_model_update >= 1 and self.step % self.target_model_update == 0:
+            self.update_target_model_hard()
+
+        return metrics

--- a/my_env.py
+++ b/my_env.py
@@ -1,0 +1,235 @@
+from random import randint
+
+import numpy as np
+import sys
+from six import StringIO, b
+
+import gym
+from gym import utils, spaces
+from gym.envs.toy_text import discrete
+from gym.utils import seeding
+
+DOWN = 0
+RIGHT = 1
+UP = 2
+LEFT = 3
+
+ACTIONS = [UP, RIGHT, DOWN, LEFT]
+
+NUM_ROWS = 4
+NUM_COLS = 4
+
+NUM_ACTIONS = len(ACTIONS)
+NUM_STATES = NUM_ROWS * NUM_COLS
+
+
+class BlockWorldEnvironmentConv(gym.Env):
+    def __init__(self, height, width, initial_x, initial_y, final_x, final_y):
+        self.height = height
+        self.width = width
+        self.initial_x = initial_x
+        self.initial_y = initial_y
+        self.my_x = initial_x
+        self.my_y = initial_y
+        self.goal_x = final_x
+        self.goal_y = final_y
+        self._DOWN = 1
+        self._UP = 0
+        self._RIGHT = 3
+        self._LEFT = 2
+        self.steps = 0
+        self.actions = [self._UP, self._DOWN, self._LEFT, self._RIGHT]
+        low = np.array([0 for i in range(64)])
+        high = np.array([2 for i in range(64)])
+        self.observation_space = spaces.Box(low, high)
+        self.action_space = spaces.Discrete(4)
+        self.reward = 0
+        self.zero = np.zeros((64,1))
+        self.done = False
+
+    def reset(self):
+        self.my_x = self.initial_x  # randint(0, self.width-1)
+        self.my_y = self.initial_y  # randint(0, self.height-1)
+        self.actions = [self._UP, self._DOWN, self._LEFT, self._RIGHT]
+        self.reward = 0
+        self.done = False
+        self.steps = 0
+
+        return np.array(self.get_state()).reshape((64,1))
+
+    def step(self, action):
+        temp_reward = 0
+        self.steps += 1
+
+        if self.my_x == self.goal_x and self.my_y == self.goal_y:
+            self.done = True
+            self.reward += 10
+            temp_reward = 10
+            return np.array(self.get_state()).reshape((64,1)), 10, self.done, {}
+        elif self.my_x == 0 and action == self._LEFT:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_x == self.width - 1 and action == self._RIGHT:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_y == 0 and action == self._DOWN:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_y == self.height - 1 and action == self._UP:
+            self.reward -= 1
+            temp_reward = -1
+        else:
+            if action == self._UP:
+                self.my_y += 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._DOWN:
+                self.my_y -= 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._LEFT:
+                self.my_x -= 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._RIGHT:
+                self.my_x += 1
+                self.reward -= 1
+                temp_reward = -1
+
+        return np.array(self.get_state()).reshape((64,1)), temp_reward, self.done, {}
+
+    def get_state(self):
+        if not self.done:
+            environment = [
+                [0 for j in range(self.width)] for i in range(self.height)
+            ]
+            environment[-self.my_y][self.my_x] = 1
+            environment[-self.goal_y][self.goal_x] = 2
+            return self._flatten(environment)
+        else:
+            return [0 for i in range(self.height*self.width)]
+
+    def _flatten(self, environment):
+        flattened = []
+        for i in range(len(environment)):
+            for j in range(len(environment[i])):
+                flattened.append(environment[i][j])
+        return flattened
+
+    def render(self, mode='human'):
+        for i in reversed(range(self.height)):
+            for j in range(self.width):
+                if i == self.my_y and j == self.my_x:
+                    print('X', end='')
+                elif i == self.goal_x and j == self.goal_y:
+                    print('G', end='')
+                else:
+                    print('0', end='')
+            print('')
+        print('')
+
+
+class BlockWorldEnvironmentNonConv(gym.Env):
+    def __init__(self, height, width, initial_x, initial_y, final_x, final_y):
+        self.height = height
+        self.width = width
+        self.initial_x = initial_x
+        self.initial_y = initial_y
+        self.my_x = initial_x
+        self.my_y = initial_y
+        self.goal_x = final_x
+        self.goal_y = final_y
+        self._DOWN = 1
+        self._UP = 0
+        self._RIGHT = 3
+        self._LEFT = 2
+        self.steps = 0
+        self.actions = [self._UP, self._DOWN, self._LEFT, self._RIGHT]
+        low = np.array([0 for i in range(64)])
+        high = np.array([2 for i in range(64)])
+        self.observation_space = spaces.Box(low, high)
+        self.action_space = spaces.Discrete(4)
+        self.reward = 0
+        self.zero = np.zeros((64,1))
+        self.done = False
+
+    def reset(self):
+        self.my_x = self.initial_x  # randint(0, self.width-1)
+        self.my_y = self.initial_y  # randint(0, self.height-1)
+        self.actions = [self._UP, self._DOWN, self._LEFT, self._RIGHT]
+        self.reward = 0
+        self.done = False
+        self.steps = 0
+
+        return np.array(self.get_state())
+
+    def step(self, action):
+        temp_reward = 0
+        self.steps += 1
+
+        if self.my_x == self.goal_x and self.my_y == self.goal_y:
+            self.done = True
+            self.reward += 10
+            temp_reward = 10
+            return np.array(self.get_state()), 10, self.done, {}
+        elif self.my_x == 0 and action == self._LEFT:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_x == self.width - 1 and action == self._RIGHT:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_y == 0 and action == self._DOWN:
+            self.reward -= 1
+            temp_reward = -1
+        elif self.my_y == self.height - 1 and action == self._UP:
+            self.reward -= 1
+            temp_reward = -1
+        else:
+            if action == self._UP:
+                self.my_y += 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._DOWN:
+                self.my_y -= 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._LEFT:
+                self.my_x -= 1
+                self.reward -= 1
+                temp_reward = -1
+            elif action == self._RIGHT:
+                self.my_x += 1
+                self.reward -= 1
+                temp_reward = -1
+
+        return np.array(self.get_state()), temp_reward, self.done, {}
+
+    def get_state(self):
+        if not self.done:
+            environment = [
+                [0 for j in range(self.width)] for i in range(self.height)
+            ]
+            environment[-self.my_y][self.my_x] = 1
+            environment[-self.goal_y][self.goal_x] = 2
+            return self._flatten(environment)
+        else:
+            return [0 for i in range(self.height*self.width)]
+
+    def _flatten(self, environment):
+        flattened = []
+        for i in range(len(environment)):
+            for j in range(len(environment[i])):
+                flattened.append(environment[i][j])
+        return flattened
+
+    def render(self, mode='human'):
+        for i in reversed(range(self.height)):
+            for j in range(self.width):
+                if i == self.my_y and j == self.my_x:
+                    print('X', end='')
+                elif i == self.goal_x and j == self.goal_y:
+                    print('G', end='')
+                else:
+                    print('0', end='')
+            print('')
+        print('')

--- a/nonconv-dqn.py
+++ b/nonconv-dqn.py
@@ -1,0 +1,58 @@
+import numpy as np
+import gym
+from my_env import BlockWorldEnvironmentNonConv
+
+from keras.models import Sequential
+from keras.layers import Dense, Activation, Flatten, Conv1D, Conv2D, Permute
+from keras.optimizers import Adam
+
+from rl.agents.dqn import DQNAgent
+from rl.policy import LinearAnnealedPolicy, BoltzmannQPolicy, EpsGreedyQPolicy
+from rl.memory import SequentialMemory
+
+
+ENV_NAME = 'CartPole-v0'
+
+
+# Get the environment and extract the number of actions.
+env = BlockWorldEnvironmentNonConv(8, 8, 1, 1, 4, 4)  #gym.make(ENV_NAME)
+np.random.seed(123)
+env.seed(123)
+nb_actions = env.action_space.n
+
+# Next, we build a very simple model.
+model = Sequential()
+"""
+model.add(Permute((1, 2), input_shape=(64,) + (1,)))
+model.add(Conv1D(5, filter_length=5, activation='linear', input_shape=(64,) + (1,)))
+model.add(Flatten())
+"""
+model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(4))
+model.add(Activation('linear'))
+print(model.summary())
+
+# Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
+# even the metrics!
+memory = SequentialMemory(limit=50000, window_length=1)
+policy = LinearAnnealedPolicy(EpsGreedyQPolicy(), attr='eps', value_max=1., value_min=.1, value_test=.05,
+nb_steps=1000000)
+dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=10,
+               target_model_update=1e-2, policy=policy)
+dqn.compile(Adam(lr=1e-3), metrics=['mae'])
+# Okay, now it's time to learn something! We visualize the training here for show, but this
+# slows down training quite a lot. You can always safely abort the training prematurely using
+# Ctrl + C.
+dqn.fit(env, nb_steps=50000, verbose=2)
+
+# After training is done, we save the final weights.
+dqn.save_weights('dqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+
+# Finally, evaluate our algorithm for 5 episodes.
+dqn.test(env, nb_episodes=5)

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -66,7 +66,9 @@ class AbstractDQNAgent(Agent):
         return q_values
 
     def compute_q_values(self, state):
-        q_values = self.compute_batch_q_values([state]).flatten()
+        #q_values = self.compute_batch_q_values([state]).flatten()
+        #import pdb; pdb.set_trace()
+        q_values = self.compute_batch_q_values(state).flatten()
         assert q_values.shape == (self.nb_actions,)
         return q_values
 
@@ -100,7 +102,7 @@ class DQNAgent(AbstractDQNAgent):
             `naive`: Q(s,a;theta) = V(s;theta) + A(s,a;theta) 
  
     """
-    def __init__(self, model, policy=None, test_policy=None, enable_double_dqn=False, enable_dueling_network=False,
+    def __init__(self, model, policy=None, test_policy=None, enable_double_dqn=True, enable_dueling_network=False,
                  dueling_type='avg', *args, **kwargs):
         super(DQNAgent, self).__init__(*args, **kwargs)
 
@@ -130,9 +132,9 @@ class DQNAgent(AbstractDQNAgent):
             # dueling_type == 'naive'
             # Q(s,a;theta) = V(s;theta) + A(s,a;theta)
             if self.dueling_type == 'avg':
-                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], -1) + a[:, 1:] - K.mean(a[:, 1:], axis=1, keepdims=True), output_shape=(nb_action,))(y)
+                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], -1) + a[:, 1:] - K.mean(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
             elif self.dueling_type == 'max':
-                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], -1) + a[:, 1:] - K.max(a[:, 1:], axis=1, keepdims=True), output_shape=(nb_action,))(y)
+                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], -1) + a[:, 1:] - K.max(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
             elif self.dueling_type == 'naive':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], -1) + a[:, 1:], output_shape=(nb_action,))(y)
             else:
@@ -260,13 +262,13 @@ class DQNAgent(AbstractDQNAgent):
             action_batch = []
             terminal1_batch = []
             state1_batch = []
+            #import pdb; pdb.set_trace()
             for e in experiences:
-                state0_batch.append(e.state0)
-                state1_batch.append(e.state1)
+                state0_batch.append(e.state0[0])  # modified this
+                state1_batch.append(e.state1[0])  # modified this
                 reward_batch.append(e.reward)
                 action_batch.append(e.action)
                 terminal1_batch.append(0. if e.terminal1 else 1.)
-
             # Prepare and validate parameters.
             state0_batch = self.process_state_batch(state0_batch)
             state1_batch = self.process_state_batch(state1_batch)


### PR DESCRIPTION
I have installed keras-rl from pip today and encountered a bug in the process.

When trying to do 1D convolution keras doesn't accept an input layer with input_shape=(1,X), it must be input_shape=(X,1). I believe this is due to the 1d conv layer needing the data shaped a certain way in order to perform convolution. The size can't be greater than the input value, so when your shape is (1,X) but you have a size of 5 it doesn't translate the convolution to the X but rather the one.

I believe I have solved this specific issue but unfortunately it breaks the ability to accept(1,X). I am posting this to bring to the developers' attention for a better solution.

I have attached my openai gym file(block world) and two files for 1dconv and non-1dconv as well as a source file of what should be changed.

Thank you for creating this package and I hope you are able to resolve the issue.