### PR TITLE
Fix automatic switching to new tf behavior in NAF

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -88,17 +88,17 @@ class AbstractDQNAgent(Agent):
 # http://arxiv.org/abs/1509.06461
 class DQNAgent(AbstractDQNAgent):
     """
-    # Arguments 
-        model__: A Keras model. 
-        policy__: A Keras-rl policy that are defined in [policy](https://github.com/keras-rl/keras-rl/blob/master/rl/policy.py). 
-        test_policy__: A Keras-rl policy. 
-        enable_double_dqn__: A boolean which enable target network as a second network proposed by van Hasselt et al. to decrease overfitting. 
-        enable_dueling_dqn__: A boolean which enable dueling architecture proposed by Mnih et al. 
-        dueling_type__: If `enable_dueling_dqn` is set to `True`, a type of dueling architecture must be chosen which calculate Q(s,a) from V(s) and A(s,a) differently. Note that `avg` is recommanded in the [paper](https://arxiv.org/abs/1511.06581). 
-            `avg`: Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-Avg_a(A(s,a;theta))) 
-            `max`: Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-max_a(A(s,a;theta))) 
-            `naive`: Q(s,a;theta) = V(s;theta) + A(s,a;theta) 
- 
+    # Arguments
+        model__: A Keras model.
+        policy__: A Keras-rl policy that are defined in [policy](https://github.com/keras-rl/keras-rl/blob/master/rl/policy.py).
+        test_policy__: A Keras-rl policy.
+        enable_double_dqn__: A boolean which enable target network as a second network proposed by van Hasselt et al. to decrease overfitting.
+        enable_dueling_dqn__: A boolean which enable dueling architecture proposed by Mnih et al.
+        dueling_type__: If `enable_dueling_dqn` is set to `True`, a type of dueling architecture must be chosen which calculate Q(s,a) from V(s) and A(s,a) differently. Note that `avg` is recommanded in the [paper](https://arxiv.org/abs/1511.06581).
+            `avg`: Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-Avg_a(A(s,a;theta)))
+            `max`: Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-max_a(A(s,a;theta)))
+            `naive`: Q(s,a;theta) = V(s;theta) + A(s,a;theta)
+
     """
     def __init__(self, model, policy=None, test_policy=None, enable_double_dqn=False, enable_dueling_network=False,
                  dueling_type='avg', *args, **kwargs):
@@ -431,7 +431,7 @@ class NAFLayer(Layer):
                 try:
                     # Old TF behavior.
                     L_flat = tf.concat(1, [zeros, L_flat])
-                except TypeError:
+                except (TypeError, ValueError):
                     # New TF behavior
                     L_flat = tf.concat([zeros, L_flat], 1)
 
@@ -500,7 +500,7 @@ class NAFLayer(Layer):
                 try:
                     # Old TF behavior.
                     L_flat = tf.concat(1, [zeros, L_flat])
-                except TypeError:
+                except (TypeError, ValueError):
                     # New TF behavior
                     L_flat = tf.concat([zeros, L_flat], 1)
 


### PR DESCRIPTION
Very simple fix to `NAFLayer` for when `tf.concat` raises a `ValueError` instead of a `TypeError` when used the old way instead of the new way, which I recently ran into when playing around with `NAFAgent`.