### PR TITLE
Improve NAF calculation and fix info processing

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -450,7 +450,7 @@ class NAFLayer(Layer):
                     # Multiply by the mask first to avoid exponentiating everything, even
                     # though we'll multiply by it again later, this saves on computation and
                     # can help prevent NaNs that might crop up during exponentiation.
-                    x_ *= diag_mask
+                    x_ = x * diag_mask
                     # Exponentiate only the elements kept by the mask, with the rest being set
                     # to e^0 = 1 as a result.
                     x_ = K.exp(x_) + K.epsilon()

--- a/rl/core.py
+++ b/rl/core.py
@@ -179,7 +179,7 @@ class Agent(object):
                     if self.processor is not None:
                         observation, r, done, info = self.processor.process_step(observation, r, done, info)
                     for key, value in info.items():
-                        if not np.isreal(value):
+                        if not np.all(np.isreal(value)):
                             continue
                         if key not in accumulated_info:
                             accumulated_info[key] = np.zeros_like(value)


### PR DESCRIPTION
Two changes with this PR:

1. Fixes an error in `Agent.fit` that prevented the use of numpy arrays as values in the info dictionary. Specifically, `np.isreal` returns an array when called on an array, which cannot then be checked for truthity unless `np.all` is called on it.

2. Improves the NAF calculation to reduce the amount of exponentiation necessary by multiplying by a diagonal mask both before and after exponentiation.