### PR TITLE
ignore info with multiple values

### DIFF
--- a/rl/core.py
+++ b/rl/core.py
@@ -179,7 +179,7 @@ class Agent(object):
                     if self.processor is not None:
                         observation, r, done, info = self.processor.process_step(observation, r, done, info)
                     for key, value in info.items():
-                        if not np.isreal(value):
+                        if len(value) > 1 or not np.isreal(value):
                             continue
                         if key not in accumulated_info:
                             accumulated_info[key] = np.zeros_like(value)
@@ -353,7 +353,7 @@ class Agent(object):
                     callbacks.on_action_end(action)
                     reward += r
                     for key, value in info.items():
-                        if not np.isreal(value):
+                        if len(value) > 1 or not np.isreal(value):
                             continue
                         if key not in accumulated_info:
                             accumulated_info[key] = np.zeros_like(value)

--- a/rl/core.py
+++ b/rl/core.py
@@ -136,7 +136,7 @@ class Agent(object):
 
                     # Perform random starts at beginning of episode and do not record them into the experience.
                     # This slightly changes the start position between games.
-                    nb_random_start_steps = 0 if nb_max_start_steps == 0 else np.random.randint(nb_max_start_steps)
+                    nb_random_start_steps = 0 if nb_max_start_steps == 0 else nb_max_start_steps
                     for _ in range(nb_random_start_steps):
                         if start_step_policy is None:
                             action = env.action_space.sample()


### PR DESCRIPTION
info currently cannot be handled if it contains multiple values. As the variable is not really necessary to train an agent, it can be ignored