### PR TITLE
Fix CEM agent (prefer 'good' weights instead of 'lucky' weights)

### DIFF
--- a/rl/agents/cem.py
+++ b/rl/agents/cem.py
@@ -90,7 +90,7 @@ class CEMAgent(Agent):
             batch = self.processor.process_state_batch(batch)
 
         action = self.model.predict_on_batch(batch).flatten()
-        if stochastic or self.training:
+        if stochastic:
             return np.random.choice(np.arange(self.nb_actions), p=np.exp(action) / np.sum(np.exp(action)))
         return np.argmax(action)
     

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -340,11 +340,11 @@ class EpisodeParameterMemory(Memory):
         return len(self.total_rewards)
 
     def get_config(self):
-        """Return configurations of SequentialMemory
+        """Return configurations of EpisodeParameterMemory
 
         # Returns
             Dict of config
         """
-        config = super(SequentialMemory, self).get_config()
+        config = super(EpisodeParameterMemory, self).get_config()
         config['limit'] = self.limit
         return config


### PR DESCRIPTION
Consider weights for `CEMAgent`. Given these weights, there are two options for action selection:
* to choose one at random with respect to output probabilities;
* to choose the one with the highest predicted probability.

At testing stage, an agent has only the latter option. However, at training stage, the former option is always activated. This is inconsistent, because it means that an agent is trained to do other things than those that are expected from it during testing/deployment.

Given weights, stochastic selection of actions may, by chance, result in abnormally high reward. However, there is no guarantee that deterministic selection of the most probable action can lead to the same reward. In general case, this does not hold true. Chances are that 'lucky' weights are preferred over 'good' weights during training. An evidence of it is that rewards at testing are lower than rewards reported at `self.best_seen`.

This pull request fixes above problem and also fixes a minor issue with `EpisodeParameterMemory`.