### PR TITLE
Issue #348: len is not well defined for symbolic Tensors

### DIFF
--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -26,9 +26,9 @@ class DDPGAgent(Agent):
                  gamma=.99, batch_size=32, nb_steps_warmup_critic=1000, nb_steps_warmup_actor=1000,
                  train_interval=1, memory_interval=1, delta_range=None, delta_clip=np.inf,
                  random_process=None, custom_model_objects={}, target_model_update=.001, **kwargs):
-        if hasattr(actor.output, '__len__') and len(actor.output) > 1:
+        if hasattr(actor.output, '__shape__') and actor.shape[0] > 1:
             raise ValueError('Actor "{}" has more than one output. DDPG expects an actor that has a single output.'.format(actor))
-        if hasattr(critic.output, '__len__') and len(critic.output) > 1:
+        if hasattr(critic.output, '__shape__') and critic.shape[0] > 1:
             raise ValueError('Critic "{}" has more than one output. DDPG expects a critic that has a single output.'.format(critic))
         if critic_action_input not in critic.input:
             raise ValueError('Critic "{}" does not have designated action input "{}".'.format(critic, critic_action_input))

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -105,7 +105,7 @@ class DQNAgent(AbstractDQNAgent):
         super(DQNAgent, self).__init__(*args, **kwargs)
 
         # Validate (important) input.
-        if hasattr(model.output, '__len__') and len(model.output) > 1:
+        if hasattr(model.output, '__shape__') and model.shape[0] > 1:
             raise ValueError('Model "{}" has more than one output. DQN expects a model that has a single output.'.format(model))
         if model.output._keras_shape != (None, self.nb_actions):
             raise ValueError('Model output "{}" has invalid shape. DQN expects a model that has one dimension for each action, in this case {}.'.format(model.output, self.nb_actions))


### PR DESCRIPTION
This only addresses the first half of Issue #348 , but was able to run examples of DQN and DDPG with:

- tensorflow 1.15.0
- keras 2.3.1